### PR TITLE
Improve Slack integration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ When creating your Slack app, the following scopes are required for comprehensiv
 
 ### Sample App Manifest
 
-For faster setup, you can use this app manifest (replace the placeholder URLs with your actual URLs):
+For faster setup, you can use this app manifest (replace the placeholder URLs with your actual URLs). You can create a new app using a manifest by clicking "Create New App" in the Slack API dashboard, then selecting "From an app manifest":
 
 ```yaml
 display_information:


### PR DESCRIPTION
## Summary
- Added clearer instructions for creating a Slack app using the app manifest
- Specified that users need to select 'From an app manifest' when creating a new app

## Test plan
- README formatting displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)