### PR TITLE
Implement Slack OAuth with ngrok support (clean)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -24,7 +24,4 @@ OPENAI_API_KEY=your_openai_api_key
 # GITHUB_CLIENT_SECRET=your_github_client_secret
 # NOTION_API_KEY=your_notion_api_key
 
-# ngrok for HTTPS in development (Slack OAuth requires HTTPS)
-# NGROK_AUTHTOKEN=your_ngrok_auth_token
-# NGROK_DOMAIN=your-reserved-domain  # If you have a reserved domain
 # NGROK_URL=https://your-ngrok-domain.ngrok-free.app  # Full HTTPS URL for API_URL

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ Thumbs.db
 
 # CDK
 infrastructure/cdk/cdk.out
+
+# NGROK
+.env.ngrok
+temp-ngrok.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,6 @@
 ## Environment Setup
 - Frontend: `npm run check-env` (verify environment variables)
 - Backend: `python scripts/check_env.py` (verify environment variables)
+
+## Development
+- Backend: Activate venv before running python.

--- a/README.md
+++ b/README.md
@@ -317,9 +317,9 @@ Forwarding  https://abc-123-xyz.ngrok-free.app -> http://localhost:8000
 2. Navigate to "OAuth & Permissions"
 3. Add the ngrok URL to the "Redirect URLs" section:
    ```
-   https://abc-123-xyz.ngrok-free.app/api/v1/slack/oauth-callback
+   https://abc-123-xyz.ngrok-free.app/auth/slack/callback
    ```
-   **IMPORTANT**: Make sure to include the `/api/v1` prefix in the URL
+   **IMPORTANT**: This URL should match the frontend callback route, not the API endpoint
 4. Save changes
 
 #### Step 5: Update environment variables

--- a/README.md
+++ b/README.md
@@ -303,13 +303,26 @@ npm install -g ngrok
 docker compose up -d
 ```
 
-#### Step 3: Start ngrok in a separate terminal
+#### Step 3: Start ngrok for the frontend
+Use the provided script to start ngrok with your authtoken:
+
 ```bash
-ngrok http 8000
+# Make the script executable if needed
+chmod +x ./scripts/start-ngrok.sh
+
+# Run the script with your authtoken
+./scripts/start-ngrok.sh your_ngrok_authtoken
+
+# Alternatively, create a .env.ngrok file with your token
+echo "NGROK_AUTHTOKEN=your_ngrok_authtoken" > .env.ngrok
+# If you have custom URL, specify NGROK_CUSTOM_DOMAIN (without https://)
+echo "NGROK_CUSTOM_DOMAIN=your_ngrok_custom_app.com" >> .env.ngrok
+./scripts/start-ngrok.sh
 ```
-This will display an output showing your ngrok URLs, for example:
+
+This will display an output showing your ngrok URL, for example:
 ```
-Forwarding  https://abc-123-xyz.ngrok-free.app -> http://localhost:8000
+Tunnel Status  app       online  https://xyz-123-abc.ngrok-free.app -> http://localhost:5173
 ```
 
 #### Step 4: Configure Slack app
@@ -317,7 +330,7 @@ Forwarding  https://abc-123-xyz.ngrok-free.app -> http://localhost:8000
 2. Navigate to "OAuth & Permissions"
 3. Add the ngrok URL to the "Redirect URLs" section:
    ```
-   https://abc-123-xyz.ngrok-free.app/auth/slack/callback
+   https://xyz-123-abc.ngrok-free.app/auth/slack/callback
    ```
    **IMPORTANT**: This URL should match the frontend callback route, not the API endpoint
 4. Save changes
@@ -330,24 +343,28 @@ SLACK_CLIENT_ID=your_slack_client_id
 SLACK_CLIENT_SECRET=your_slack_client_secret
 SLACK_SIGNING_SECRET=your_slack_signing_secret
 
-# Use ngrok URL 
-NGROK_URL=https://abc-123-xyz.ngrok-free.app
+# ngrok URL (from the output of the ngrok command)
+NGROK_URL=https://xyz-123-abc.ngrok-free.app
+
+# Required for ngrok configuration
+NGROK_AUTHTOKEN=your_ngrok_auth_token
 ```
 
-#### Step 6: Restart the backend container
+#### Step 6: Restart the containers
 ```bash
-docker compose restart backend
+docker compose restart
 ```
 
 #### Step 7: Test the OAuth flow
-1. Navigate to the frontend at http://localhost:5173
+1. Navigate to the frontend at your ngrok URL (e.g., https://xyz-123-abc.ngrok-free.app)
 2. Go to the Slack connection page
 3. Click "Connect to Slack" to initiate the OAuth flow
 
 #### Important notes
-- The ngrok URL changes each time you restart ngrok unless you have a paid account with a reserved domain
-- Remember to update both your Slack app settings and `.env.docker` file when the URL changes
-- For persistent development, consider upgrading to ngrok Pro for a fixed subdomain
+- The ngrok URLs change each time you restart ngrok unless you have a paid account with a reserved domain
+- Remember to update both your Slack app settings and `.env.docker` file when the URLs change
+- For persistent development, consider upgrading to ngrok Pro for fixed subdomains
+- The frontend must be accessible via HTTPS for the complete OAuth flow to work correctly
 
 ### Sample App Manifest
 
@@ -366,9 +383,9 @@ features:
 
 oauth_config:
   redirect_urls:
-    - https://your-app-domain.com/api/v1/slack/oauth-callback
-    - http://localhost:8000/api/v1/slack/oauth-callback
-    - https://your-ngrok-url.ngrok-free.app/api/v1/slack/oauth-callback
+    - https://your-app-domain.com/auth/slack/callback
+    - http://localhost:5173/auth/slack/callback
+    - https://your-ngrok-app-url.ngrok-free.app/auth/slack/callback
   scopes:
     bot:
       - channels:history

--- a/backend/app/api/v1/slack/oauth.py
+++ b/backend/app/api/v1/slack/oauth.py
@@ -45,14 +45,11 @@ class SlackOAuthResponse(BaseModel):
 
 @router.get("/oauth-url")
 async def get_oauth_url(
-    redirect_uri: Optional[str] = Query(None),
+    # No longer accepting redirect_uri from frontend
 ) -> Dict[str, str]:
     """
     Generate OAuth URL for Slack.
-
-    Args:
-        redirect_uri: Optional redirect URI override. If not provided, uses the default.
-
+    
     Returns:
         Dictionary containing the OAuth URL.
     """
@@ -81,8 +78,7 @@ async def get_oauth_url(
         "user_scope": "",  # No user tokens needed for our use case
     }
 
-    # Always use the backend URL for the callback to ensure it matches the Slack app settings
-    # Ignore any redirect_uri provided from frontend to ensure consistency with Slack app config
+    # Always use our controlled URLs for the callback to ensure it matches the Slack app settings
     
     # Get base URL from settings.FRONTEND_URL (which should be the ngrok app URL if provided)
     # or construct it from API_URL
@@ -116,7 +112,9 @@ async def get_oauth_url(
     
     # Log debugging information
     logger.info(f"Settings API_URL: {settings.API_URL}")
-    logger.info(f"Using base URL: {base_url}")
+    # Only log base_url if we're using API_URL path (not frontend_url or default)
+    if not settings.FRONTEND_URL and settings.API_URL:
+        logger.info(f"Using base URL: {base_url}")
     logger.info(f"Using redirect URI: {params['redirect_uri']}")
 
     oauth_url = f"https://slack.com/oauth/v2/authorize?{urlencode(params)}"

--- a/backend/app/api/v1/slack/oauth.py
+++ b/backend/app/api/v1/slack/oauth.py
@@ -84,9 +84,14 @@ async def get_oauth_url(
     # Always use the backend URL for the callback to ensure it matches the Slack app settings
     # Ignore any redirect_uri provided from frontend to ensure consistency with Slack app config
     
-    # Get base URL from settings.API_URL (which should be the ngrok URL if provided)
-    # Use the frontend URL for the redirect to show a nice UI after OAuth
-    if settings.API_URL:
+    # Get base URL from settings.FRONTEND_URL (which should be the ngrok app URL if provided)
+    # or construct it from API_URL
+    if settings.FRONTEND_URL:
+        # Use the FRONTEND_URL directly if it's configured
+        frontend_base_url = str(settings.FRONTEND_URL).rstrip("/")
+        frontend_callback = f"{frontend_base_url}/auth/slack/callback"
+        logger.info(f"Using frontend URL directly: {frontend_base_url}")
+    elif settings.API_URL:
         # Extract the base domain from API_URL
         api_url = str(settings.API_URL).rstrip("/")
         
@@ -101,9 +106,11 @@ async def get_oauth_url(
             base_url = api_url
             
         frontend_callback = f"{base_url}/auth/slack/callback"
+        logger.info(f"Extracted base URL from API_URL: {base_url}")
     else:
         # Default for local development - use frontend URL
         frontend_callback = "http://localhost:5173/auth/slack/callback"
+        logger.info("Using default local frontend URL")
     
     params["redirect_uri"] = frontend_callback
     

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     API_PREFIX: str = "/api/v1"
     DEBUG: bool = False
     API_URL: Optional[str] = None  # Base URL for the API, used for constructing callback URLs (e.g., ngrok URL)
+    FRONTEND_URL: Optional[str] = None  # Base URL for the frontend, used for redirects (e.g., ngrok app URL)
     ALLOWED_HOSTS: List[str] = [
         "http://localhost:5173", 
         "http://localhost:8000", 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     API_URL: Optional[str] = None  # Base URL for the API, used for constructing callback URLs (e.g., ngrok URL)
     FRONTEND_URL: Optional[str] = None  # Base URL for the frontend, used for redirects (e.g., ngrok app URL)
+    ADDITIONAL_CORS_ORIGINS: str = ""  # Comma-separated list of additional CORS origins
     ALLOWED_HOSTS: List[str] = [
         "http://localhost:5173", 
         "http://localhost:8000", 
@@ -26,6 +27,19 @@ class Settings(BaseSettings):
         "https://*.ngrok-free.app",
         "https://*.ngrok.io",
     ]
+    
+    @validator("ALLOWED_HOSTS", pre=True)
+    def add_additional_cors_origins(cls, v, values):
+        """Add any additional CORS origins from the environment."""
+        allowed_hosts = list(v)
+        additional_cors = values.get("ADDITIONAL_CORS_ORIGINS", "")
+        
+        if additional_cors:
+            # Split by comma and filter out empty strings
+            origins = [origin.strip() for origin in additional_cors.split(",") if origin.strip()]
+            allowed_hosts.extend(origins)
+            
+        return allowed_hosts
 
     # Secret Keys
     SECRET_KEY: str

--- a/backend/docs/integrations/slack-oauth.md
+++ b/backend/docs/integrations/slack-oauth.md
@@ -72,9 +72,9 @@ ngrok http 8000
 - Copy the HTTPS URL from ngrok (e.g., `https://abc-123-xyz.ngrok-free.app`)
 - In Slack app settings under "OAuth & Permissions", add:
   ```
-  https://abc-123-xyz.ngrok-free.app/api/v1/slack/oauth-callback
+  https://abc-123-xyz.ngrok-free.app/auth/slack/callback
   ```
-  **IMPORTANT**: Make sure to include the `/api/v1` prefix in the URL
+  **IMPORTANT**: This URL must match the frontend callback route, not the API endpoint
 
 #### 3. Configure Environment Variables
 Update your `.env.docker` file with:

--- a/config/ngrok/ngrok.yml
+++ b/config/ngrok/ngrok.yml
@@ -1,9 +1,0 @@
-version: 2
-# Placeholder - copy this file and add your authtoken
-# authtoken: your_ngrok_authtoken
-web_addr: 0.0.0.0:4040
-tunnels:
-  app:
-    proto: http
-    addr: http://localhost:5173
-    inspect: false

--- a/config/ngrok/ngrok.yml
+++ b/config/ngrok/ngrok.yml
@@ -1,7 +1,9 @@
 version: 2
-authtoken: ${NGROK_AUTHTOKEN}
+# Placeholder - copy this file and add your authtoken
+# authtoken: your_ngrok_authtoken
 web_addr: 0.0.0.0:4040
 tunnels:
-  api:
+  app:
     proto: http
-    addr: backend:8000
+    addr: http://localhost:5173
+    inspect: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       # API and Frontend URLs 
       - API_URL=http://localhost:8000
       - FRONTEND_URL=${NGROK_URL:-http://localhost:5173}
+      # Add ngrok URL to CORS allowed origins
+      - ADDITIONAL_CORS_ORIGINS=${NGROK_URL:-}
       # For debugging
       - DEBUG_NGROK_URL=${NGROK_URL:-}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
@@ -68,7 +70,7 @@ services:
       # Use anonymous volume to prevent node_modules from being overwritten
       - /app/node_modules
     environment:
-      # API URL - always use localhost since it's accessed from the browser
+      # API URL for browser requests - always use localhost since we're in a browser context
       - VITE_API_URL=http://localhost:8000/api/v1
       # Frontend URL for redirects (use ngrok tunnel if available)
       - VITE_FRONTEND_URL=${NGROK_URL:-http://localhost:5173}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,10 +41,11 @@ services:
       - SLACK_CLIENT_ID=${SLACK_CLIENT_ID}
       - SLACK_CLIENT_SECRET=${SLACK_CLIENT_SECRET}
       - SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET}
-      # API URL for the backend (use ngrok URL if available)
-      # Print the actual NGROK_URL value for debugging
-      - API_URL=${NGROK_URL:-http://localhost:8000}
-      - DEBUG_NGROK_URL=${NGROK_URL}
+      # API and Frontend URLs 
+      - API_URL=http://localhost:8000
+      - FRONTEND_URL=${NGROK_URL:-http://localhost:5173}
+      # For debugging
+      - DEBUG_NGROK_URL=${NGROK_URL:-}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
       - NOTION_API_KEY=${NOTION_API_KEY:-}
@@ -67,11 +68,13 @@ services:
       # Use anonymous volume to prevent node_modules from being overwritten
       - /app/node_modules
     environment:
-      # API URL needs to be localhost since it's accessed from the browser
+      # API URL - always use localhost since it's accessed from the browser
       - VITE_API_URL=http://localhost:8000/api/v1
+      # Frontend URL for redirects (use ngrok tunnel if available)
+      - VITE_FRONTEND_URL=${NGROK_URL:-http://localhost:5173}
       - VITE_SUPABASE_URL=${SUPABASE_URL:-your_supabase_url}
       - VITE_SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY:-your_supabase_anon_key}
-      - VITE_AUTH_REDIRECT_URI=http://localhost:5173/auth/callback
+      - VITE_AUTH_REDIRECT_URI=${NGROK_URL:-http://localhost:5173}/auth/callback
       - VITE_DEV_MODE=true
       - VITE_ENABLE_NOTION_INTEGRATION=true
       - VITE_ENABLE_SLACK_INTEGRATION=true

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Toban Contribution Viewer</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,7 +64,7 @@ function App() {
                 }
               />
               <Route
-                path="/api/v1/slack/oauth-callback"
+                path="/auth/slack/callback"
                 element={<SlackOAuthCallbackPage />}
               />
             </Routes>

--- a/frontend/src/components/slack/ConnectWorkspace.tsx
+++ b/frontend/src/components/slack/ConnectWorkspace.tsx
@@ -15,9 +15,8 @@ const ConnectWorkspace: React.FC = () => {
     try {
       setIsLoading(true);
       
-      // Get OAuth URL from backend with redirect URI
-      const redirectUri = `${window.location.origin}${import.meta.env.VITE_API_URL}/slack/oauth-callback`;
-      const response = await fetch(`${import.meta.env.VITE_API_URL}/slack/oauth-url?redirect_uri=${encodeURIComponent(redirectUri)}`);
+      // Get OAuth URL from backend without a redirect URI (let the backend determine it)
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/slack/oauth-url`);
       
       if (!response.ok) {
         const error = await response.json();

--- a/frontend/src/components/slack/OAuthCallback.tsx
+++ b/frontend/src/components/slack/OAuthCallback.tsx
@@ -32,7 +32,7 @@ const OAuthCallback: React.FC = () => {
       try {
         // Send code to backend
         const response = await fetch(
-          `${import.meta.env.VITE_API_URL}/api/v1/slack/oauth-callback?code=${code}`
+          `${import.meta.env.VITE_API_URL}/slack/oauth-callback?code=${code}&redirect_from_frontend=true`
         );
         
         if (!response.ok) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,43 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  // Load env variables based on mode
+  const env = loadEnv(mode, process.cwd());
+  
+  // Extract domain from NGROK_URL if it exists
+  let allowedHosts = [];
+  if (env.VITE_FRONTEND_URL || process.env.NGROK_URL) {
+    try {
+      const url = new URL(env.VITE_FRONTEND_URL || process.env.NGROK_URL || '');
+      if (url.hostname) {
+        allowedHosts.push(url.hostname);
+      }
+    } catch (e) {
+      console.warn('Could not parse NGROK_URL', e);
+    }
+  }
+  
+  // Add specific ngrok domain if needed
+  allowedHosts.push('summary-locust-arriving.ngrok-free.app');
+  // Add generic ngrok domains
+  allowedHosts.push('*.ngrok-free.app');
+  allowedHosts.push('*.ngrok.io');
+  
+  return {
+    plugins: [react()],
+    server: {
+      host: '0.0.0.0',
+      port: 5173,
+      strictPort: true,
+      hmr: {
+        // Allow HMR from different hosts
+        clientPort: 5173
+      },
+      cors: true,
+      // Allow connections from these hosts
+      allowedHosts
+    }
+  }
 })

--- a/scripts/start-ngrok.sh
+++ b/scripts/start-ngrok.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Script to start ngrok for Slack OAuth
+# Usage: ./start-ngrok.sh [authtoken]
+
+set -e
+
+# Check if authtoken is provided as argument or in .env.ngrok file
+if [ -n "$1" ]; then
+  NGROK_AUTHTOKEN="$1"
+elif [ -f ".env.ngrok" ]; then
+  source .env.ngrok
+else
+  echo "Error: Ngrok authtoken required."
+  echo "Either provide it as an argument: ./start-ngrok.sh your_authtoken"
+  echo "Or create a .env.ngrok file with: NGROK_AUTHTOKEN=your_authtoken"
+  exit 1
+fi
+
+if [ -z "$NGROK_AUTHTOKEN" ]; then
+  echo "Error: NGROK_AUTHTOKEN is not set"
+  exit 1
+fi
+
+# Create temporary ngrok config
+TMP_CONFIG="./temp-ngrok.yml"
+
+echo "Creating temporary ngrok configuration..."
+cat > "$TMP_CONFIG" << EOF
+version: 2
+authtoken: $NGROK_AUTHTOKEN
+web_addr: 0.0.0.0:4040
+tunnels:
+  app:
+    proto: http
+    addr: http://localhost:5173
+    inspect: false
+    hostname: ${NGROK_CUSTOM_DOMAIN:-}
+EOF
+
+# Function to clean up on exit
+cleanup() {
+  echo "Cleaning up temporary files..."
+  rm -f "$TMP_CONFIG"
+}
+
+# Register the cleanup function to be called on exit
+trap cleanup EXIT
+
+echo "Starting ngrok for frontend (http://localhost:5173)..."
+echo "Press Ctrl+C to stop"
+echo ""
+echo "Once ngrok is running, update your .env.docker file with:"
+echo "NGROK_URL=https://your-ngrok-url.ngrok-free.app"
+echo ""
+echo "And configure your Slack App's redirect URL to:"
+echo "https://your-ngrok-url.ngrok-free.app/auth/slack/callback"
+echo ""
+
+# Start ngrok
+ngrok start --config="$TMP_CONFIG" app

--- a/scripts/start-ngrok.sh
+++ b/scripts/start-ngrok.sh
@@ -50,11 +50,11 @@ echo "Starting ngrok for frontend (http://localhost:5173)..."
 echo "Press Ctrl+C to stop"
 echo ""
 echo "Once ngrok is running, update your .env.docker file with:"
-echo "NGROK_URL=https://your-ngrok-url.ngrok-free.app"
+echo "NGROK_URL=https://your-frontend-ngrok-url.ngrok-free.app"
 echo ""
 echo "And configure your Slack App's redirect URL to:"
-echo "https://your-ngrok-url.ngrok-free.app/auth/slack/callback"
+echo "https://your-frontend-ngrok-url.ngrok-free.app/auth/slack/callback"
 echo ""
 
-# Start ngrok
+# Start ngrok for the frontend only
 ngrok start --config="$TMP_CONFIG" app


### PR DESCRIPTION
## Summary
- Implement Slack OAuth integration with working ngrok support for local development
- Add utility script for easy ngrok tunnel setup
- Configure proper CORS handling for cross-domain access
- Update environment variables handling for development

## Changes
- Create `scripts/start-ngrok.sh` utility for simple ngrok setup
- Update ngrok.yml configuration to focus on the frontend
- Add ADDITIONAL_CORS_ORIGINS to allow cross-domain API access
- Update environment variable handling in docker-compose.yml
- Configure backend to properly handle frontend URL from environment
- Improve documentation with detailed setup instructions

## Testing
- Set up ngrok using the new script
- Configure Slack app with the frontend ngrok URL
- Test the OAuth flow from authorization to callback
- Verify proper workspace connection

This PR contains a simple and robust implementation of Slack OAuth that works correctly with ngrok for local development.

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)