### PR TITLE
Fix navigation after channel selection

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -76,6 +76,14 @@ function App() {
                   </ProtectedRoute>
                 }
               />
+              <Route
+                path="/dashboard/slack/workspaces/:workspaceId"
+                element={
+                  <ProtectedRoute>
+                    <SlackWorkspacesPage />
+                  </ProtectedRoute>
+                }
+              />
             </Routes>
           </Container>
         </AuthProvider>


### PR DESCRIPTION
## Summary
- Added missing route for `/dashboard/slack/workspaces/:workspaceId` to fix routing error
- This fixes the blank page issue after saving channel selection

## Problem
After selecting channels and saving, the app navigates to `/dashboard/slack/workspaces/:workspaceId` but this route wasn't defined, causing a blank page and a console error:
```
No routes matched location "/dashboard/slack/workspaces/{workspaceId}"
```

## Test plan
- Select channels for a workspace and save the selection
- Verify that the app navigates correctly to the workspace page instead of showing a blank page

🤖 Generated with [Claude Code](https://claude.ai/code)