### PR TITLE
Add channels:join scope to documentation

### DIFF
--- a/backend/docs/integrations/slack-oauth.md
+++ b/backend/docs/integrations/slack-oauth.md
@@ -14,6 +14,7 @@ This guide explains how to set up and test the Slack OAuth integration in the To
 3. Provide an app name (e.g., "Toban Contribution Viewer") and select your development workspace
 4. In the "OAuth & Permissions" section, add the following scopes:
    - `channels:history`
+   - `channels:join` - Required for auto-installing the bot in channels
    - `channels:read`
    - `groups:history`
    - `groups:read`

--- a/backend/docs/testing/slack-channel-testing.md
+++ b/backend/docs/testing/slack-channel-testing.md
@@ -110,6 +110,7 @@ A successful test means that:
 2. **Authentication errors**:
    - Verify that your token has the required scopes:
      - `channels:read`
+     - `channels:join` - Required for auto-installing the bot in channels
      - `groups:read`
      - `im:read`
      - `mpim:read`


### PR DESCRIPTION
## Summary
- Added `channels:join` scope to the Slack OAuth permissions documentation
- This scope is required for the auto-installing bot functionality in channels
- Updated both the OAuth setup and channel testing documentation

## Problem
When selecting channels and auto-installing the bot, users were getting this error:
```
Selected 1 channels for analysis. Failed to install in 1 channel.
``` 

The server logs showed:
```
tobancv-backend | 2025-04-11 23:41:30,598 - app.services.slack.channels - INFO - Attempting to join channel proj-oss-boardgame (C08JP0V9VT8)
tobancv-backend | 2025-04-11 23:41:30,863 - app.services.slack.api - ERROR - Slack API error: missing_scope - Unknown API error
```

This was caused by missing the `channels:join` scope in the Slack app configuration.

## Test plan
- Review documentation for accuracy and completeness
- The docs now correctly list all required scopes for the application

🤖 Generated with [Claude Code](https://claude.ai/code)