### PR TITLE
Fix isort configuration to match GitHub Actions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     -   id: isort
         files: ^backend/
         types: [python]
+        args: ["--profile=black"]
 
 # The following checks are disabled for local development but run in CI
 # Commented out since CI will handle these checks

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 120

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -9,14 +9,7 @@ per-file-ignores =
     app/services/slack/channels.py: C901, E501
     app/api/v1/slack/channels.py: C901, E501
 
-[isort]
-profile = black
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-ensure_newline_before_comments = True
-line_length = 120
+# isort configuration moved to pyproject.toml
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
## Summary
- Move isort configuration from setup.cfg to pyproject.toml
- Update pre-commit hook to explicitly use black profile
- This ensures consistent sorting behavior between local and CI environments

## Test plan
- Run pre-commit hooks locally: `pre-commit run --all-files`
- Confirm that isort runs with the same configuration as GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)