### PR TITLE
Add Slack message API endpoints

### DIFF
--- a/backend/app/api/v1/slack/messages.py
+++ b/backend/app/api/v1/slack/messages.py
@@ -1,0 +1,215 @@
+"""
+Slack messages API routes.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_async_db
+from app.services.slack.messages import SlackMessageService
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["slack_messages"])
+
+
+class DateRangeRequest(BaseModel):
+    """Request model for date range filtering."""
+
+    start_date: datetime = Field(..., description="Start date for message filtering")
+    end_date: datetime = Field(..., description="End date for message filtering")
+    include_replies: bool = Field(True, description="Whether to include thread replies")
+
+
+@router.get("/workspaces/{workspace_id}/channels/{channel_id}/messages")
+async def get_channel_messages(
+    workspace_id: str,
+    channel_id: str,
+    start_date: Optional[datetime] = Query(
+        None, description="Start date for message filtering"
+    ),
+    end_date: Optional[datetime] = Query(
+        None, description="End date for message filtering"
+    ),
+    include_replies: bool = Query(
+        True, description="Whether to include thread replies"
+    ),
+    limit: int = Query(
+        100, ge=1, le=1000, description="Maximum number of messages to retrieve"
+    ),
+    cursor: Optional[str] = Query(None, description="Pagination cursor"),
+    db: AsyncSession = Depends(get_async_db),
+) -> Dict[str, Any]:
+    """
+    Get messages from a specific channel with optional date filtering and pagination.
+
+    Args:
+        workspace_id: UUID of the workspace
+        channel_id: UUID of the channel
+        start_date: Optional start date for filtering messages
+        end_date: Optional end date for filtering messages
+        include_replies: Whether to include thread replies
+        limit: Maximum number of messages to retrieve
+        cursor: Pagination cursor for retrieving the next set of results
+        db: Database session
+
+    Returns:
+        Dictionary with messages and pagination information
+    """
+    try:
+        logger.info(
+            f"Fetching messages for channel {channel_id} in workspace {workspace_id}, "
+            f"date range: {start_date} to {end_date}, limit: {limit}, cursor: {cursor}"
+        )
+
+        result = await SlackMessageService.get_channel_messages(
+            db=db,
+            workspace_id=workspace_id,
+            channel_id=channel_id,
+            start_date=start_date,
+            end_date=end_date,
+            limit=limit,
+            cursor=cursor,
+            include_replies=include_replies,
+        )
+
+        logger.info(
+            f"Retrieved {len(result.get('messages', []))} messages for channel {channel_id}"
+        )
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching channel messages: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail="An error occurred while retrieving channel messages",
+        )
+
+
+@router.get("/workspaces/{workspace_id}/messages")
+async def get_messages_by_date_range(
+    workspace_id: str,
+    channel_ids: List[str] = Query(..., description="List of channel UUIDs to include"),
+    start_date: datetime = Query(..., description="Start date for message filtering"),
+    end_date: datetime = Query(..., description="End date for message filtering"),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(
+        100, ge=1, le=1000, description="Number of messages per page"
+    ),
+    db: AsyncSession = Depends(get_async_db),
+) -> Dict[str, Any]:
+    """
+    Get messages from multiple channels filtered by date range with pagination.
+
+    Args:
+        workspace_id: UUID of the workspace
+        channel_ids: List of channel UUIDs to include
+        start_date: Start date for filtering messages
+        end_date: End date for filtering messages
+        page: Page number for pagination
+        page_size: Number of messages per page
+        db: Database session
+
+    Returns:
+        Dictionary with messages and pagination information
+    """
+    try:
+        logger.info(
+            f"Fetching messages for workspace {workspace_id} across {len(channel_ids)} channels, "
+            f"date range: {start_date} to {end_date}, page: {page}, page_size: {page_size}"
+        )
+
+        result = await SlackMessageService.get_messages_by_date_range(
+            db=db,
+            workspace_id=workspace_id,
+            channel_ids=channel_ids,
+            start_date=start_date,
+            end_date=end_date,
+            page=page,
+            page_size=page_size,
+        )
+
+        logger.info(
+            f"Retrieved {len(result.get('messages', []))} messages across multiple channels"
+        )
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching messages by date range: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail="An error occurred while retrieving messages"
+        )
+
+
+@router.post("/workspaces/{workspace_id}/channels/{channel_id}/sync")
+async def sync_channel_messages(
+    workspace_id: str,
+    channel_id: str,
+    date_range: Optional[DateRangeRequest] = None,
+    background_tasks: BackgroundTasks = BackgroundTasks(),
+    include_replies: bool = Query(
+        True, description="Whether to include thread replies"
+    ),
+    batch_size: int = Query(
+        200, ge=50, le=1000, description="Number of messages per batch"
+    ),
+    db: AsyncSession = Depends(get_async_db),
+) -> Dict[str, Any]:
+    """
+    Sync messages from a Slack channel to the database.
+
+    This endpoint initiates a background task for syncing messages to prevent timeouts.
+    It returns immediately with a status message while the sync continues in the background.
+
+    Args:
+        workspace_id: UUID of the workspace
+        channel_id: UUID of the channel
+        date_range: Optional date range for filtering messages
+        background_tasks: FastAPI background tasks handler
+        include_replies: Whether to include thread replies
+        batch_size: Number of messages to process in each batch
+        db: Database session
+
+    Returns:
+        Dictionary with status information
+    """
+    try:
+        logger.info(
+            f"Initiating message sync for channel {channel_id} in workspace {workspace_id}, "
+            f"date range: {date_range.start_date if date_range else None} to "
+            f"{date_range.end_date if date_range else None}, batch_size: {batch_size}"
+        )
+
+        # Start the sync process in a background task
+        background_tasks.add_task(
+            SlackMessageService.sync_channel_messages,
+            db=db,
+            workspace_id=workspace_id,
+            channel_id=channel_id,
+            start_date=date_range.start_date if date_range else None,
+            end_date=date_range.end_date if date_range else None,
+            include_replies=include_replies,
+            batch_size=batch_size,
+        )
+
+        return {
+            "status": "syncing",
+            "message": "Message synchronization started. This process will continue in the background and may take a few minutes depending on the date range and message volume.",
+            "workspace_id": workspace_id,
+            "channel_id": channel_id,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error initiating message sync: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail="An error occurred while initiating message sync"
+        )

--- a/backend/app/api/v1/slack/router.py
+++ b/backend/app/api/v1/slack/router.py
@@ -5,6 +5,7 @@ Main router for Slack API endpoints.
 from fastapi import APIRouter
 
 from app.api.v1.slack.channels import router as channels_router
+from app.api.v1.slack.messages import router as messages_router
 from app.api.v1.slack.oauth import router as oauth_router
 
 router = APIRouter(prefix="/slack", tags=["slack"])
@@ -14,3 +15,6 @@ router.include_router(oauth_router, prefix="")
 
 # Include routes from channels.py
 router.include_router(channels_router, prefix="")
+
+# Include routes from messages.py
+router.include_router(messages_router, prefix="")

--- a/backend/tests/api/v1/slack/test_messages.py
+++ b/backend/tests/api/v1/slack/test_messages.py
@@ -21,6 +21,10 @@ from app.models.slack import SlackChannel, SlackMessage, SlackWorkspace
 def mock_slack_message_service():
     """Create a mock for the SlackMessageService."""
     with patch("app.api.v1.slack.messages.SlackMessageService") as mock:
+        # Setup async methods to return awaitable objects
+        mock.get_channel_messages = AsyncMock()
+        mock.get_messages_by_date_range = AsyncMock()
+        mock.sync_channel_messages = AsyncMock()
         yield mock
 
 

--- a/backend/tests/api/v1/slack/test_messages.py
+++ b/backend/tests/api/v1/slack/test_messages.py
@@ -2,19 +2,16 @@
 Tests for the Slack messages API endpoints.
 """
 
-import json
 import uuid
 from datetime import datetime, timedelta
 from typing import Dict
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.slack.messages import router as messages_router
-from app.models.slack import SlackChannel, SlackMessage, SlackWorkspace
 
 
 @pytest.fixture

--- a/backend/tests/api/v1/slack/test_messages.py
+++ b/backend/tests/api/v1/slack/test_messages.py
@@ -175,6 +175,10 @@ def test_sync_channel_messages(
     client: TestClient,
 ):
     """Test the sync_channel_messages endpoint."""
+    # Configure mock to return a completed future to avoid warning
+    mock_result = {"status": "success", "message": "Sync started"}
+    mock_slack_message_service.sync_channel_messages.return_value = mock_result
+
     # Make the request
     date_range = {
         "start_date": (datetime.now() - timedelta(days=7)).isoformat(),

--- a/backend/tests/api/v1/slack/test_messages.py
+++ b/backend/tests/api/v1/slack/test_messages.py
@@ -169,15 +169,14 @@ def test_get_messages_by_date_range(
 
 def test_sync_channel_messages(
     app: FastAPI,
-    mock_slack_message_service,
     mock_workspace_id,
     mock_channel_id,
     client: TestClient,
 ):
     """Test the sync_channel_messages endpoint."""
-    # Configure mock to return a completed future to avoid warning
-    mock_result = {"status": "success", "message": "Sync started"}
-    mock_slack_message_service.sync_channel_messages.return_value = mock_result
+    # For this test, we don't need to mock SlackMessageService.sync_channel_messages
+    # since we're testing the API endpoint that uses a BackgroundTask, not the actual
+    # synchronization function
 
     # Make the request
     date_range = {

--- a/backend/tests/api/v1/slack/test_messages.py
+++ b/backend/tests/api/v1/slack/test_messages.py
@@ -1,0 +1,192 @@
+"""
+Tests for the Slack messages API endpoints.
+"""
+
+import json
+import uuid
+from datetime import datetime, timedelta
+from typing import Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.slack.messages import router as messages_router
+from app.models.slack import SlackChannel, SlackMessage, SlackWorkspace
+
+
+@pytest.fixture
+def mock_slack_message_service():
+    """Create a mock for the SlackMessageService."""
+    with patch("app.api.v1.slack.messages.SlackMessageService") as mock:
+        yield mock
+
+
+@pytest.fixture
+def app(mock_slack_message_service) -> FastAPI:
+    """Create a FastAPI test app with our router."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(messages_router, prefix="/api/v1/slack")
+    return app
+
+
+@pytest.fixture
+def mock_uuid():
+    """Generate consistent UUIDs for testing."""
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def mock_channel_id(mock_uuid):
+    """Create a mock channel ID."""
+    return mock_uuid
+
+
+@pytest.fixture
+def mock_workspace_id(mock_uuid):
+    """Create a mock workspace ID."""
+    return mock_uuid
+
+
+@pytest.fixture
+def mock_message_response() -> Dict:
+    """Create a mock message response."""
+    return {
+        "messages": [
+            {
+                "id": str(uuid.uuid4()),
+                "slack_id": "message123",
+                "slack_ts": "1612345678.123456",
+                "text": "Hello, world!",
+                "message_type": "message",
+                "subtype": None,
+                "is_edited": False,
+                "edited_ts": None,
+                "has_attachments": False,
+                "thread_ts": None,
+                "is_thread_parent": False,
+                "is_thread_reply": False,
+                "reply_count": 0,
+                "reply_users_count": 0,
+                "reaction_count": 0,
+                "message_datetime": datetime.now().isoformat(),
+                "channel_id": str(uuid.uuid4()),
+                "user_id": str(uuid.uuid4()),
+                "parent_id": None,
+            }
+        ],
+        "pagination": {
+            "has_more": False,
+            "next_cursor": None,
+            "page_size": 100,
+            "total_messages": 1,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_channel_messages(
+    app: FastAPI,
+    mock_slack_message_service,
+    mock_workspace_id,
+    mock_channel_id,
+    mock_message_response,
+    client: AsyncClient,
+):
+    """Test the get_channel_messages endpoint."""
+    # Configure the mock
+    mock_slack_message_service.get_channel_messages = AsyncMock(
+        return_value=mock_message_response
+    )
+
+    # Make the request
+    response = await client.get(
+        f"/api/v1/slack/workspaces/{mock_workspace_id}/channels/{mock_channel_id}/messages",
+        params={
+            "start_date": (datetime.now() - timedelta(days=7)).isoformat(),
+            "end_date": datetime.now().isoformat(),
+            "include_replies": True,
+            "limit": 100,
+        },
+    )
+
+    # Assert the response
+    assert response.status_code == 200
+    response_data = response.json()
+    assert "messages" in response_data
+    assert "pagination" in response_data
+    assert len(response_data["messages"]) == 1
+
+    # Verify the mock was called with the expected parameters
+    mock_slack_message_service.get_channel_messages.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_messages_by_date_range(
+    app: FastAPI,
+    mock_slack_message_service,
+    mock_workspace_id,
+    mock_message_response,
+    client: AsyncClient,
+):
+    """Test the get_messages_by_date_range endpoint."""
+    # Configure the mock
+    mock_slack_message_service.get_messages_by_date_range = AsyncMock(
+        return_value=mock_message_response
+    )
+
+    # Make the request
+    response = await client.get(
+        f"/api/v1/slack/workspaces/{mock_workspace_id}/messages",
+        params={
+            "channel_ids": [str(uuid.uuid4()), str(uuid.uuid4())],
+            "start_date": (datetime.now() - timedelta(days=7)).isoformat(),
+            "end_date": datetime.now().isoformat(),
+            "page": 1,
+            "page_size": 100,
+        },
+    )
+
+    # Assert the response
+    assert response.status_code == 200
+    response_data = response.json()
+    assert "messages" in response_data
+    assert "pagination" in response_data
+
+    # Verify the mock was called with the expected parameters
+    mock_slack_message_service.get_messages_by_date_range.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_sync_channel_messages(
+    app: FastAPI,
+    mock_slack_message_service,
+    mock_workspace_id,
+    mock_channel_id,
+    client: AsyncClient,
+):
+    """Test the sync_channel_messages endpoint."""
+    # Make the request
+    date_range = {
+        "start_date": (datetime.now() - timedelta(days=7)).isoformat(),
+        "end_date": datetime.now().isoformat(),
+        "include_replies": True,
+    }
+
+    response = await client.post(
+        f"/api/v1/slack/workspaces/{mock_workspace_id}/channels/{mock_channel_id}/sync",
+        json=date_range,
+        params={"batch_size": 200, "include_replies": True},
+    )
+
+    # Assert the response
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["status"] == "syncing"
+    assert "message" in response_data
+    assert response_data["workspace_id"] == mock_workspace_id
+    assert response_data["channel_id"] == mock_channel_id


### PR DESCRIPTION
## Summary
- Create a comprehensive API for Slack message retrieval and synchronization
- Implement endpoints for channel messages, multi-channel date-range filtering, and background message syncing
- Add complete test suite for message API endpoints
- Support pagination and thread handling

## Test plan
- Run pytest on the test_messages.py file
- Manually test API endpoints by:
  1. Accessing channel messages endpoint with and without date filters
  2. Testing the multi-channel message retrieval with date range
  3. Initiating a message sync and verifying messages are stored in the database

Part of Issue #38 - Build service to retrieve message history from selected channels

🤖 Generated with [Claude Code](https://claude.ai/code)