### PR TITLE
Fix Slack channel sync API parameter mismatch

### DIFF
--- a/backend/app/services/slack/api.py
+++ b/backend/app/services/slack/api.py
@@ -221,7 +221,11 @@ class SlackApiClient:
             return False
 
     async def get_channels(
-        self, cursor: Optional[str] = None, limit: int = 100
+        self,
+        cursor: Optional[str] = None,
+        limit: int = 100,
+        types: str = "public_channel,private_channel",
+        exclude_archived: bool = False,
     ) -> Dict[str, Any]:
         """
         Get channels in the workspace.
@@ -229,14 +233,19 @@ class SlackApiClient:
         Args:
             cursor: Pagination cursor
             limit: Number of channels to fetch
+            types: Channel types to include (comma-separated)
+            exclude_archived: Whether to exclude archived channels
 
         Returns:
             Channels and pagination info
         """
         params = {
-            "types": "public_channel,private_channel",
+            "types": types,
             "limit": limit,
         }
+
+        if exclude_archived:
+            params["exclude_archived"] = "true"
 
         if cursor:
             params["cursor"] = cursor


### PR DESCRIPTION
## Summary
- Fixed issue in channel sync where the API client method `get_channels()` was missing parameters that were being passed to it
- Added `types` and `exclude_archived` parameters to the API client implementation
- This fixes the error: `get_channels() got an unexpected keyword argument 'types'` that occurred during channel sync

## Test plan
1. Reset the database
2. Connect a Slack workspace
3. Sync channels - verify no errors occur
4. Verify channels are properly synced with different types (public, private, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)