### PR TITLE
Add channel filtering for analytics pages

### DIFF
--- a/backend/app/api/v1/slack/channels.py
+++ b/backend/app/api/v1/slack/channels.py
@@ -137,6 +137,12 @@ async def list_channels(
     include_archived: bool = Query(False, description="Include archived channels"),
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(100, ge=1, le=1000, description="Number of items per page"),
+    bot_installed_only: bool = Query(
+        False, description="Only include channels where the bot is installed"
+    ),
+    selected_for_analysis_only: bool = Query(
+        False, description="Only include channels selected for analysis"
+    ),
 ) -> Dict[str, Any]:
     """
     List channels for a workspace with pagination.
@@ -164,6 +170,8 @@ async def list_channels(
             include_archived=include_archived,
             page=page,
             page_size=page_size,
+            bot_installed_only=bot_installed_only,
+            selected_for_analysis_only=selected_for_analysis_only,
         )
 
         logger.info(

--- a/frontend/src/pages/slack/AnalyticsPage.tsx
+++ b/frontend/src/pages/slack/AnalyticsPage.tsx
@@ -116,9 +116,9 @@ const AnalyticsPage: React.FC = () => {
     try {
       setIsLoadingChannels(true);
       
-      // Create URL with query parameters to get only channels selected for analysis
+      // Create URL with query parameters to get only bot-installed or selected channels
       const queryParams = new URLSearchParams({
-        selected_for_analysis_only: 'true',
+        bot_installed_only: 'true',
         include_archived: 'false'
       });
       

--- a/frontend/src/pages/slack/AnalyticsPage.tsx
+++ b/frontend/src/pages/slack/AnalyticsPage.tsx
@@ -116,9 +116,9 @@ const AnalyticsPage: React.FC = () => {
     try {
       setIsLoadingChannels(true);
       
-      // Create URL with query parameters to get only bot-installed or selected channels
+      // Create URL with query parameters to get only channels selected for analysis
       const queryParams = new URLSearchParams({
-        bot_installed_only: 'true',
+        selected_for_analysis_only: 'true',
         include_archived: 'false'
       });
       

--- a/frontend/src/pages/slack/AnalyticsPage.tsx
+++ b/frontend/src/pages/slack/AnalyticsPage.tsx
@@ -115,8 +115,15 @@ const AnalyticsPage: React.FC = () => {
   const fetchChannels = async (workspaceId: string) => {
     try {
       setIsLoadingChannels(true);
+      
+      // Create URL with query parameters to get only bot-installed or selected channels
+      const queryParams = new URLSearchParams({
+        bot_installed_only: 'true',
+        include_archived: 'false'
+      });
+      
       const response = await fetch(
-        `${env.apiUrl}/slack/workspaces/${workspaceId}/channels`
+        `${env.apiUrl}/slack/workspaces/${workspaceId}/channels?${queryParams}`
       );
       
       if (!response.ok) {
@@ -124,15 +131,11 @@ const AnalyticsPage: React.FC = () => {
       }
       
       const data = await response.json();
-      // Filter out archived channels
-      const activeChannels = (data.channels || []).filter(
-        (channel: Channel) => !channel.is_archived
-      );
-      setChannels(activeChannels);
+      setChannels(data.channels || []);
       
       // Set the first channel as selected if available
-      if (activeChannels.length > 0) {
-        setSelectedChannel(activeChannels[0].id);
+      if (data.channels && data.channels.length > 0) {
+        setSelectedChannel(data.channels[0].id);
       } else {
         setSelectedChannel('');
       }

--- a/frontend/src/pages/slack/ChannelAnalysisPage.tsx
+++ b/frontend/src/pages/slack/ChannelAnalysisPage.tsx
@@ -136,18 +136,21 @@ const ChannelAnalysisPage: React.FC = () => {
         }
       }
       
-      // Fetch channel info
+      // Fetch channel info - get all channels then find the specific one
       const channelResponse = await fetch(
         `${env.apiUrl}/slack/workspaces/${workspaceId}/channels`
       );
       
       if (channelResponse.ok) {
         const channelsData = await channelResponse.json();
-        const matchedChannel = channelsData.channels.find(
-          (c: Channel) => c.id === channelId
-        );
-        if (matchedChannel) {
-          setChannel(matchedChannel);
+        // Find the specific channel by ID
+        if (channelsData.channels && Array.isArray(channelsData.channels)) {
+          const matchedChannel = channelsData.channels.find(
+            (c: Channel) => c.id === channelId
+          );
+          if (matchedChannel) {
+            setChannel(matchedChannel);
+          }
         }
       }
     } catch (error) {

--- a/frontend/src/pages/slack/ChannelAnalysisPage.tsx
+++ b/frontend/src/pages/slack/ChannelAnalysisPage.tsx
@@ -136,9 +136,13 @@ const ChannelAnalysisPage: React.FC = () => {
         }
       }
       
-      // Fetch channel info - get all channels then find the specific one
+      // Fetch channel info - get only bot-installed channels
+      const queryParams = new URLSearchParams({
+        bot_installed_only: 'true'
+      });
+      
       const channelResponse = await fetch(
-        `${env.apiUrl}/slack/workspaces/${workspaceId}/channels`
+        `${env.apiUrl}/slack/workspaces/${workspaceId}/channels?${queryParams}`
       );
       
       if (channelResponse.ok) {

--- a/frontend/src/pages/slack/ChannelAnalysisPage.tsx
+++ b/frontend/src/pages/slack/ChannelAnalysisPage.tsx
@@ -308,9 +308,11 @@ const ChannelAnalysisPage: React.FC = () => {
               </FormControl>
             </HStack>
             
-            <FormHelperText>
-              Select a date range and options for analysis. A larger date range will take longer to analyze.
-            </FormHelperText>
+            <FormControl>
+              <FormHelperText>
+                Select a date range and options for analysis. A larger date range will take longer to analyze.
+              </FormHelperText>
+            </FormControl>
             
             <Divider />
             


### PR DESCRIPTION
## Summary
- Add API filtering parameters (bot_installed_only and selected_for_analysis_only) to the Slack channels endpoint
- Update frontend analytics components to use these filters to show only relevant channels
- Fix Chakra UI FormHelperText context issue in ChannelAnalysisPage

## Test plan
- Verify that the analytics pages only show channels where the bot is installed
- Verify that the channel selection works correctly with the filtered results
- Verify that the UI renders correctly without console errors

🤖 Generated with [Claude Code](https://claude.ai/code)