### PR TITLE
Fix sidebar menu design issue with unwanted vertical lines

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -63,9 +63,13 @@ const NavItem = React.memo(({ icon, to, children, isActive, badge, badgeColorSch
       _hover={{ bg: isActive ? activeBg : hoverBg }}
       role="group"
     >
-      <HStack spacing={3} overflow="hidden">
-        <Icon as={icon} w={5} h={5} />
-        <Text overflow="hidden" textOverflow="ellipsis">
+      <HStack spacing={3} width="100%" overflow="hidden" css={{
+        '&::-webkit-scrollbar': { display: 'none' },
+        'scrollbarWidth': 'none',
+        '-ms-overflow-style': 'none',
+      }}>
+        <Icon as={icon} w={5} h={5} flexShrink={0} />
+        <Text overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
           {children}
         </Text>
         {badge && (
@@ -74,6 +78,7 @@ const NavItem = React.memo(({ icon, to, children, isActive, badge, badgeColorSch
             colorScheme={badgeColorScheme || 'blue'}
             borderRadius="full"
             px={2}
+            flexShrink={0}
           >
             {badge}
           </Badge>
@@ -136,7 +141,11 @@ const Sidebar = ({ onClose, ...rest }: SidebarProps) => {
         </Box>
       )}
       
-      <Box mx={3}>
+      <Box mx={3} overflowY="auto" css={{
+        '&::-webkit-scrollbar': { width: '0px' },
+        'scrollbarWidth': 'none',
+        '-ms-overflow-style': 'none',
+      }}>
         {/* Main Navigation */}
         <List spacing={1}>
           <ListItem>


### PR DESCRIPTION
## Summary
- Fixed issue where blue vertical lines/scrollbars were appearing in the sidebar menu after certain items
- Added CSS to hide scrollbars while maintaining proper text overflow functionality
- Ensured menu item text remains properly contained with text-overflow ellipsis
- Improved HStack and Icon flexbox properties to prevent layout distortion

## Test plan
1. Navigate through the application using the sidebar menu
2. Verify no blue vertical lines appear after menu items
3. Verify long menu labels are properly truncated with ellipsis
4. Test on both light and dark themes

🤖 Generated with [Claude Code](https://claude.ai/code)