### PR TITLE
Fix sidebar menu background width issue

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -62,6 +62,8 @@ const NavItem = React.memo(({ icon, to, children, isActive, badge, badgeColorSch
       bg={isActive ? activeBg : undefined}
       _hover={{ bg: isActive ? activeBg : hoverBg }}
       role="group"
+      width="100%"
+      display="block"
     >
       <HStack spacing={3} overflow="hidden">
         <Icon as={icon} w={5} h={5} />


### PR DESCRIPTION
## Summary
- Fixed issue where the active menu item background was being cut off and not spanning the full width
- Added width: 100% to the menu item Box component
- Set display: block to ensure proper Box sizing
- This ensures the blue highlight spans the entire width of the sidebar menu items

## Test plan
1. Navigate through the application using the sidebar menu
2. Verify active menu items have a background that spans the full width of the sidebar
3. Test on both light and dark themes

🤖 Generated with [Claude Code](https://claude.ai/code)