### PR TITLE
Create Integration API Service (#122)

### DIFF
--- a/frontend/src/__tests__/lib/integrationService.test.ts
+++ b/frontend/src/__tests__/lib/integrationService.test.ts
@@ -1,6 +1,4 @@
-/// <reference types="vitest" />
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import * as vi from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import integrationService, { 
   Integration, 
   IntegrationType, 

--- a/frontend/src/__tests__/lib/integrationService.test.ts
+++ b/frontend/src/__tests__/lib/integrationService.test.ts
@@ -70,7 +70,7 @@ describe('Integration API Service', () => {
     vi.clearAllMocks();
     
     // Set up supabase auth mock for each test
-    (supabase.auth.getSession as vi.Mock).mockResolvedValue({
+    (supabase.auth.getSession as ReturnType<typeof vi.fn>).mockResolvedValue({
       data: {
         session: {
           access_token: 'mock-token'

--- a/frontend/src/__tests__/lib/integrationService.test.ts
+++ b/frontend/src/__tests__/lib/integrationService.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+/// <reference types="vitest" />
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as vi from 'vitest';
 import integrationService, { 
   Integration, 
   IntegrationType, 
@@ -7,7 +9,9 @@ import integrationService, {
   IntegrationShare,
   ShareLevel,
   AccessLevel,
-  ApiError
+  ApiError,
+  ResourceType,
+  CreateSlackIntegrationRequest
 } from '../../lib/integrationService';
 import { supabase } from '../../lib/supabase';
 
@@ -541,7 +545,7 @@ describe('Integration API Service', () => {
         json: () => Promise.resolve(mockIntegration)
       });
       
-      const slackData = {
+      const slackData: CreateSlackIntegrationRequest = {
         name: 'Test Slack Integration',
         service_type: IntegrationType.SLACK,
         team_id: mockTeamId,

--- a/frontend/src/__tests__/lib/integrationService.test.ts
+++ b/frontend/src/__tests__/lib/integrationService.test.ts
@@ -54,7 +54,7 @@ describe('Integration API Service', () => {
     {
       id: mockResourceId,
       integration_id: mockIntegrationId,
-      resource_type: 'slack_channel' as any,
+      resource_type: ResourceType.SLACK_CHANNEL,
       external_id: 'C12345',
       name: 'general',
       metadata: { topic: 'General discussions' },
@@ -336,7 +336,7 @@ describe('Integration API Service', () => {
       
       await integrationService.getResources(
         mockIntegrationId, 
-        ['slack_channel', 'slack_user'] as any[]
+        [ResourceType.SLACK_CHANNEL, ResourceType.SLACK_USER]
       );
       
       expect(mockFetch).toHaveBeenCalledWith(

--- a/frontend/src/__tests__/lib/integrationService.test.ts
+++ b/frontend/src/__tests__/lib/integrationService.test.ts
@@ -1,0 +1,565 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import integrationService, { 
+  Integration, 
+  IntegrationType, 
+  IntegrationStatus, 
+  ServiceResource,
+  IntegrationShare,
+  ShareLevel,
+  AccessLevel,
+  ApiError
+} from '../../lib/integrationService';
+import { supabase } from '../../lib/supabase';
+
+// Mock the supabase module
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn()
+    }
+  }
+}));
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('Integration API Service', () => {
+  const mockTeamId = '123e4567-e89b-12d3-a456-426614174000';
+  const mockIntegrationId = '123e4567-e89b-12d3-a456-426614174001';
+  const mockResourceId = '123e4567-e89b-12d3-a456-426614174002';
+  
+  const mockIntegration: Integration = {
+    id: mockIntegrationId,
+    name: 'Test Integration',
+    description: 'Test Description',
+    service_type: IntegrationType.SLACK,
+    status: IntegrationStatus.ACTIVE,
+    metadata: { test: 'data' },
+    owner_team: {
+      id: mockTeamId,
+      name: 'Test Team',
+      slug: 'test-team'
+    },
+    created_by: {
+      id: 'user123',
+      email: 'test@example.com',
+      name: 'Test User'
+    },
+    created_at: '2025-04-15T12:00:00Z',
+    updated_at: '2025-04-15T12:00:00Z'
+  };
+  
+  const mockResources: ServiceResource[] = [
+    {
+      id: mockResourceId,
+      integration_id: mockIntegrationId,
+      resource_type: 'slack_channel' as any,
+      external_id: 'C12345',
+      name: 'general',
+      metadata: { topic: 'General discussions' },
+      created_at: '2025-04-15T12:00:00Z',
+      updated_at: '2025-04-15T12:00:00Z'
+    }
+  ];
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    vi.clearAllMocks();
+    
+    // Set up supabase auth mock for each test
+    (supabase.auth.getSession as vi.Mock).mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'mock-token'
+        }
+      }
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Helper function to let async code process
+  const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
+
+  describe('getAuthHeaders', () => {
+    it('should include the auth token in headers', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([mockIntegration])
+      });
+
+      // Request the integrations
+      const promise = integrationService.getIntegrations(mockTeamId);
+      
+      // Wait for promises to resolve
+      await flushPromises();
+      
+      // Check the headers used in the fetch call
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Authorization': 'Bearer mock-token'
+          })
+        })
+      );
+      
+      // Verify supabase getSession was called
+      expect(supabase.auth.getSession).toHaveBeenCalled();
+      
+      // Await the promise to complete the test
+      await promise;
+    });
+  });
+
+  describe('getIntegrations', () => {
+    it('should fetch integrations successfully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([mockIntegration])
+      });
+
+      // Start the request
+      const resultPromise = integrationService.getIntegrations(mockTeamId);
+      
+      // Wait for promises to resolve
+      await flushPromises();
+      
+      // Verify fetch was called correctly
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/integrations?team_id=${mockTeamId}`),
+        expect.any(Object)
+      );
+      
+      // Check the result
+      const result = await resultPromise;
+      expect(result).toEqual([mockIntegration]);
+    });
+
+    it('should handle error when fetching integrations', async () => {
+      const errorResponse = {
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden'
+      };
+      
+      // Need to use mockImplementationOnce for errorResponse to be properly
+      // available to handleError method
+      mockFetch.mockImplementationOnce(() => Promise.resolve(errorResponse));
+
+      // Start the request
+      const resultPromise = integrationService.getIntegrations(mockTeamId);
+      
+      // Wait for promises to resolve
+      await flushPromises();
+      
+      // Check the result
+      const result = await resultPromise;
+      expect(result).toEqual({
+        status: 403,
+        message: 'Forbidden'
+      });
+    });
+
+    it('should include service type when specified', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([mockIntegration])
+      });
+
+      // Start the request
+      const resultPromise = integrationService.getIntegrations(mockTeamId, IntegrationType.SLACK);
+      
+      // Wait for promises to resolve
+      await flushPromises();
+      
+      // Verify fetch was called with correct parameters
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`team_id=${mockTeamId}&service_type=${IntegrationType.SLACK}`),
+        expect.any(Object)
+      );
+      
+      // Complete the test
+      await resultPromise;
+    });
+  });
+
+  describe('getIntegration', () => {
+    it('should fetch a single integration by ID', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockIntegration)
+      });
+
+      const result = await integrationService.getIntegration(mockIntegrationId);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/integrations/${mockIntegrationId}`),
+        expect.any(Object)
+      );
+      
+      expect(result).toEqual(mockIntegration);
+    });
+
+    it('should handle error when fetching integration', async () => {
+      const errorResponse = {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found'
+      };
+      
+      mockFetch.mockImplementationOnce(() => Promise.resolve(errorResponse));
+
+      // Start the request
+      const resultPromise = integrationService.getIntegration(mockIntegrationId);
+      
+      // Wait for promises to resolve
+      await flushPromises();
+      
+      // Check the result
+      const result = await resultPromise;
+      expect(result).toEqual({
+        status: 404,
+        message: 'Not Found'
+      });
+    });
+  });
+
+  describe('createIntegration', () => {
+    it('should create an integration successfully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockIntegration)
+      });
+
+      const createData = {
+        name: 'Test Integration',
+        service_type: IntegrationType.SLACK,
+        description: 'Test Description',
+        team_id: mockTeamId
+      };
+      
+      const result = await integrationService.createIntegration(createData);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/integrations'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(createData)
+        })
+      );
+      
+      expect(result).toEqual(mockIntegration);
+    });
+
+    it('should handle error when creating integration', async () => {
+      const errorResponse = {
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request'
+      };
+      
+      mockFetch.mockImplementationOnce(() => Promise.resolve(errorResponse));
+
+      const createData = {
+        name: 'Test Integration',
+        service_type: IntegrationType.SLACK,
+        team_id: mockTeamId
+      };
+      
+      // Start the request
+      const resultPromise = integrationService.createIntegration(createData);
+      
+      // Wait for promises to resolve
+      await flushPromises();
+      
+      // Check the result
+      const result = await resultPromise;
+      expect(result).toEqual({
+        status: 400,
+        message: 'Bad Request'
+      });
+    });
+  });
+
+  describe('updateIntegration', () => {
+    it('should update an integration successfully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockIntegration)
+      });
+
+      const updateData = {
+        name: 'Updated Integration Name',
+        status: IntegrationStatus.DISCONNECTED
+      };
+      
+      const result = await integrationService.updateIntegration(mockIntegrationId, updateData);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/integrations/${mockIntegrationId}`),
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify(updateData)
+        })
+      );
+      
+      expect(result).toEqual(mockIntegration);
+    });
+  });
+
+  describe('getResources', () => {
+    it('should fetch resources for an integration', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResources)
+      });
+      
+      const result = await integrationService.getResources(mockIntegrationId);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/integrations/${mockIntegrationId}/resources`),
+        expect.any(Object)
+      );
+      
+      expect(result).toEqual(mockResources);
+    });
+
+    it('should include resource type filters when specified', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResources)
+      });
+      
+      await integrationService.getResources(
+        mockIntegrationId, 
+        ['slack_channel', 'slack_user'] as any[]
+      );
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('resource_type=slack_channel&resource_type=slack_user'),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('syncResources', () => {
+    it('should sync resources successfully', async () => {
+      const syncResponse = {
+        status: 'success',
+        message: 'Resources synced successfully',
+        synced: {
+          channels: 10,
+          users: 20
+        }
+      };
+      
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(syncResponse)
+      });
+      
+      const result = await integrationService.syncResources(mockIntegrationId);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/integrations/${mockIntegrationId}/sync`),
+        expect.objectContaining({
+          method: 'POST'
+        })
+      );
+      
+      expect(result).toEqual(syncResponse);
+    });
+  });
+
+  describe('shareIntegration', () => {
+    it('should share an integration with another team', async () => {
+      const shareResponse: IntegrationShare = {
+        id: '123e4567-e89b-12d3-a456-426614174003',
+        integration_id: mockIntegrationId,
+        team_id: 'target-team-id',
+        share_level: ShareLevel.READ_ONLY,
+        status: 'active',
+        shared_by: {
+          id: 'user123',
+          name: 'Test User'
+        },
+        team: {
+          id: 'target-team-id',
+          name: 'Target Team',
+          slug: 'target-team'
+        },
+        created_at: '2025-04-15T12:00:00Z',
+        updated_at: '2025-04-15T12:00:00Z'
+      };
+      
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(shareResponse)
+      });
+      
+      const shareData = {
+        team_id: 'target-team-id',
+        share_level: ShareLevel.READ_ONLY
+      };
+      
+      const result = await integrationService.shareIntegration(mockIntegrationId, shareData);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/integrations/${mockIntegrationId}/share`),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(shareData)
+        })
+      );
+      
+      expect(result).toEqual(shareResponse);
+    });
+  });
+
+  describe('revokeShare', () => {
+    it('should revoke an integration share', async () => {
+      const revokeResponse = {
+        status: 'success',
+        message: 'Share revoked successfully'
+      };
+      
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(revokeResponse)
+      });
+      
+      const targetTeamId = 'target-team-id';
+      const result = await integrationService.revokeShare(mockIntegrationId, targetTeamId);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/integrations/${mockIntegrationId}/share/${targetTeamId}`),
+        expect.objectContaining({
+          method: 'DELETE'
+        })
+      );
+      
+      expect(result).toEqual(revokeResponse);
+    });
+  });
+
+  describe('grantResourceAccess', () => {
+    it('should grant access to a resource', async () => {
+      const accessResponse = {
+        id: '123e4567-e89b-12d3-a456-426614174004',
+        resource_id: mockResourceId,
+        team_id: 'target-team-id',
+        access_level: AccessLevel.READ,
+        granted_by: {
+          id: 'user123',
+          name: 'Test User'
+        },
+        team: {
+          id: 'target-team-id',
+          name: 'Target Team',
+          slug: 'target-team'
+        },
+        created_at: '2025-04-15T12:00:00Z',
+        updated_at: '2025-04-15T12:00:00Z'
+      };
+      
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(accessResponse)
+      });
+      
+      const accessData = {
+        team_id: 'target-team-id',
+        access_level: AccessLevel.READ
+      };
+      
+      const result = await integrationService.grantResourceAccess(
+        mockIntegrationId, 
+        mockResourceId, 
+        accessData
+      );
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/integrations/${mockIntegrationId}/resources/${mockResourceId}/access`),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(accessData)
+        })
+      );
+      
+      expect(result).toEqual(accessResponse);
+    });
+  });
+
+  describe('isApiError', () => {
+    it('should correctly identify API errors', () => {
+      const apiError: ApiError = {
+        status: 404,
+        message: 'Not Found'
+      };
+      
+      expect(integrationService.isApiError(apiError)).toBe(true);
+      expect(integrationService.isApiError(null)).toBe(false);
+      expect(integrationService.isApiError({})).toBe(false);
+      expect(integrationService.isApiError({ status: 404 })).toBe(false);
+      expect(integrationService.isApiError({ message: 'Error' })).toBe(false);
+      expect(integrationService.isApiError(mockIntegration)).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle network errors gracefully', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+      
+      const result = await integrationService.getIntegrations(mockTeamId);
+      
+      expect(result).toEqual({
+        status: 500,
+        message: 'Network error'
+      });
+    });
+
+    it('should handle non-Response errors', async () => {
+      mockFetch.mockRejectedValueOnce('Unknown error');
+      
+      const result = await integrationService.getIntegrations(mockTeamId);
+      
+      expect(result).toEqual({
+        status: 500,
+        message: 'Failed to fetch integrations'
+      });
+    });
+  });
+
+  describe('createSlackIntegration', () => {
+    it('should create a Slack integration using OAuth', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockIntegration)
+      });
+      
+      const slackData = {
+        name: 'Test Slack Integration',
+        service_type: IntegrationType.SLACK,
+        team_id: mockTeamId,
+        code: 'oauth-code',
+        redirect_uri: 'http://localhost:3000/callback'
+      };
+      
+      const result = await integrationService.createSlackIntegration(slackData);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/integrations/slack'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(slackData)
+        })
+      );
+      
+      expect(result).toEqual(mockIntegration);
+    });
+  });
+});

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Library exports for all services and utilities
+ */
+
+export { default as supabase } from './supabase';
+export * from './supabase';
+export { default as integrationService } from './integrationService';
+export * from './integrationService';

--- a/frontend/src/lib/integrationService.ts
+++ b/frontend/src/lib/integrationService.ts
@@ -202,6 +202,7 @@ class IntegrationService {
   private handleError(error: unknown, defaultMessage: string): ApiError {
     console.error('API Error:', error);
     
+    // Handle Response objects
     if (error instanceof Response) {
       return {
         status: error.status,
@@ -209,6 +210,17 @@ class IntegrationService {
       };
     }
     
+    // Handle response-like objects (for testing or other scenarios)
+    if (error && typeof error === 'object' && 'ok' in error && !error.ok && 
+        'status' in error && 'statusText' in error) {
+      const responseError = error as { status: number; statusText: string };
+      return {
+        status: responseError.status,
+        message: responseError.statusText || defaultMessage,
+      };
+    }
+    
+    // Default error handling
     return {
       status: 500,
       message: error instanceof Error ? error.message : defaultMessage,

--- a/frontend/src/lib/integrationService.ts
+++ b/frontend/src/lib/integrationService.ts
@@ -1,0 +1,481 @@
+/**
+ * Integration API Service
+ * Handles all communication with the integration endpoints of the backend API
+ */
+
+import env from '../config/env';
+import { supabase } from './supabase';
+
+// Types for integration service
+export enum IntegrationType {
+  SLACK = 'slack',
+  GITHUB = 'github',
+  NOTION = 'notion',
+  DISCORD = 'discord',
+}
+
+export enum IntegrationStatus {
+  ACTIVE = 'active',
+  DISCONNECTED = 'disconnected',
+  EXPIRED = 'expired',
+  REVOKED = 'revoked',
+  ERROR = 'error',
+}
+
+export enum ShareLevel {
+  FULL_ACCESS = 'full_access',
+  LIMITED_ACCESS = 'limited_access',
+  READ_ONLY = 'read_only',
+}
+
+export enum ResourceType {
+  // Slack resources
+  SLACK_CHANNEL = 'slack_channel',
+  SLACK_USER = 'slack_user',
+  SLACK_EMOJI = 'slack_emoji',
+
+  // GitHub resources
+  GITHUB_REPOSITORY = 'github_repository',
+  GITHUB_ISSUE = 'github_issue',
+  GITHUB_PR = 'github_pr',
+  GITHUB_WEBHOOK = 'github_webhook',
+
+  // Notion resources
+  NOTION_PAGE = 'notion_page',
+  NOTION_DATABASE = 'notion_database',
+  NOTION_BLOCK = 'notion_block',
+
+  // Discord resources
+  DISCORD_GUILD = 'discord_guild',
+  DISCORD_CHANNEL = 'discord_channel',
+}
+
+export enum AccessLevel {
+  READ = 'read',
+  WRITE = 'write',
+  ADMIN = 'admin',
+}
+
+// Basic team and user info
+export interface TeamInfo {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export interface UserInfo {
+  id: string;
+  email?: string;
+  name?: string;
+}
+
+// Integration data types
+export interface Integration {
+  id: string;
+  name: string;
+  description?: string;
+  service_type: IntegrationType;
+  status: IntegrationStatus;
+  metadata?: Record<string, unknown>;
+  last_used_at?: string;
+  
+  owner_team: TeamInfo;
+  created_by: UserInfo;
+  created_at: string;
+  updated_at: string;
+  
+  credentials?: CredentialInfo[];
+  resources?: ServiceResource[];
+  shared_with?: IntegrationShare[];
+}
+
+export interface ServiceResource {
+  id: string;
+  integration_id: string;
+  resource_type: ResourceType;
+  external_id: string;
+  name: string;
+  metadata?: Record<string, unknown>;
+  last_synced_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface IntegrationShare {
+  id: string;
+  integration_id: string;
+  team_id: string;
+  share_level: ShareLevel;
+  status: string;
+  revoked_at?: string;
+  shared_by: UserInfo;
+  team: TeamInfo;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ResourceAccess {
+  id: string;
+  resource_id: string;
+  team_id: string;
+  access_level: AccessLevel;
+  granted_by: UserInfo;
+  team: TeamInfo;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CredentialInfo {
+  id: string;
+  credential_type: string;
+  expires_at?: string;
+  scopes?: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+// Request types
+export interface CreateIntegrationRequest {
+  name: string;
+  service_type: IntegrationType;
+  description?: string;
+  team_id: string;
+}
+
+export interface CreateSlackIntegrationRequest extends CreateIntegrationRequest {
+  service_type: IntegrationType.SLACK;
+  code: string;
+  redirect_uri: string;
+}
+
+export interface UpdateIntegrationRequest {
+  name?: string;
+  description?: string;
+  status?: IntegrationStatus;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntegrationShareRequest {
+  team_id: string;
+  share_level: ShareLevel;
+}
+
+export interface ResourceAccessRequest {
+  team_id: string;
+  access_level: AccessLevel;
+}
+
+// Error types
+export interface ApiError {
+  status: number;
+  message: string;
+  details?: unknown;
+}
+
+/**
+ * Integration Service class 
+ */
+class IntegrationService {
+  private apiUrl: string;
+  
+  constructor() {
+    this.apiUrl = `${env.apiUrl}/integrations`;
+  }
+  
+  /**
+   * Helper method to create auth headers
+   */
+  private async getAuthHeaders(): Promise<HeadersInit> {
+    const { data: { session } } = await supabase.auth.getSession();
+    const token = session?.access_token;
+    
+    return {
+      'Content-Type': 'application/json',
+      'Authorization': token ? `Bearer ${token}` : '',
+      'Origin': window.location.origin,
+    };
+  }
+  
+  /**
+   * Helper method to handle API errors
+   */
+  private handleError(error: unknown, defaultMessage: string): ApiError {
+    console.error('API Error:', error);
+    
+    if (error instanceof Response) {
+      return {
+        status: error.status,
+        message: error.statusText || defaultMessage,
+      };
+    }
+    
+    return {
+      status: 500,
+      message: error instanceof Error ? error.message : defaultMessage,
+    };
+  }
+  
+  /**
+   * Get all integrations for a team
+   */
+  async getIntegrations(teamId: string, serviceType?: IntegrationType): Promise<Integration[] | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders();
+      let url = `${this.apiUrl}?team_id=${teamId}`;
+      
+      if (serviceType) {
+        url += `&service_type=${serviceType}`;
+      }
+      
+      const response = await fetch(url, {
+        method: 'GET',
+        headers,
+        credentials: 'include',
+      });
+      
+      if (!response.ok) {
+        throw response;
+      }
+      
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      return this.handleError(error, 'Failed to fetch integrations');
+    }
+  }
+  
+  /**
+   * Get a single integration by ID
+   */
+  async getIntegration(integrationId: string): Promise<Integration | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders();
+      const response = await fetch(`${this.apiUrl}/${integrationId}`, {
+        method: 'GET',
+        headers,
+        credentials: 'include',
+      });
+      
+      if (!response.ok) {
+        throw response;
+      }
+      
+      return await response.json();
+    } catch (error) {
+      return this.handleError(error, 'Failed to fetch integration');
+    }
+  }
+  
+  /**
+   * Create a new integration
+   */
+  async createIntegration(data: CreateIntegrationRequest): Promise<Integration | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders();
+      const response = await fetch(this.apiUrl, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify(data),
+      });
+      
+      if (!response.ok) {
+        throw response;
+      }
+      
+      return await response.json();
+    } catch (error) {
+      return this.handleError(error, 'Failed to create integration');
+    }
+  }
+  
+  /**
+   * Create a new Slack integration using OAuth
+   */
+  async createSlackIntegration(data: CreateSlackIntegrationRequest): Promise<Integration | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders();
+      const response = await fetch(`${this.apiUrl}/slack`, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify(data),
+      });
+      
+      if (!response.ok) {
+        throw response;
+      }
+      
+      return await response.json();
+    } catch (error) {
+      return this.handleError(error, 'Failed to create Slack integration');
+    }
+  }
+  
+  /**
+   * Update an integration
+   */
+  async updateIntegration(integrationId: string, data: UpdateIntegrationRequest): Promise<Integration | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders();
+      const response = await fetch(`${this.apiUrl}/${integrationId}`, {
+        method: 'PUT',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify(data),
+      });
+      
+      if (!response.ok) {
+        throw response;
+      }
+      
+      return await response.json();
+    } catch (error) {
+      return this.handleError(error, 'Failed to update integration');
+    }
+  }
+  
+  /**
+   * Get integration resources
+   */
+  async getResources(integrationId: string, resourceTypes?: ResourceType[]): Promise<ServiceResource[] | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders();
+      let url = `${this.apiUrl}/${integrationId}/resources`;
+      
+      if (resourceTypes && resourceTypes.length > 0) {
+        const resourceTypeParams = resourceTypes.map(type => `resource_type=${type}`).join('&');
+        url += `?${resourceTypeParams}`;
+      }
+      
+      const response = await fetch(url, {
+        method: 'GET',
+        headers,
+        credentials: 'include',
+      });
+      
+      if (!response.ok) {
+        throw response;
+      }
+      
+      return await response.json();
+    } catch (error) {
+      return this.handleError(error, 'Failed to fetch resources');
+    }
+  }
+  
+  /**
+   * Sync integration resources
+   */
+  async syncResources(integrationId: string, resourceTypes?: string[]): Promise<Record<string, unknown> | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders();
+      let url = `${this.apiUrl}/${integrationId}/sync`;
+      
+      if (resourceTypes && resourceTypes.length > 0) {
+        const resourceTypeParams = resourceTypes.map(type => `resource_types=${type}`).join('&');
+        url += `?${resourceTypeParams}`;
+      }
+      
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+      });
+      
+      if (!response.ok) {
+        throw response;
+      }
+      
+      return await response.json();
+    } catch (error) {
+      return this.handleError(error, 'Failed to sync resources');
+    }
+  }
+  
+  /**
+   * Share an integration with another team
+   */
+  async shareIntegration(integrationId: string, data: IntegrationShareRequest): Promise<IntegrationShare | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders();
+      const response = await fetch(`${this.apiUrl}/${integrationId}/share`, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify(data),
+      });
+      
+      if (!response.ok) {
+        throw response;
+      }
+      
+      return await response.json();
+    } catch (error) {
+      return this.handleError(error, 'Failed to share integration');
+    }
+  }
+  
+  /**
+   * Revoke an integration share
+   */
+  async revokeShare(integrationId: string, teamId: string): Promise<{ status: string; message: string } | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders();
+      const response = await fetch(`${this.apiUrl}/${integrationId}/share/${teamId}`, {
+        method: 'DELETE',
+        headers,
+        credentials: 'include',
+      });
+      
+      if (!response.ok) {
+        throw response;
+      }
+      
+      return await response.json();
+    } catch (error) {
+      return this.handleError(error, 'Failed to revoke share');
+    }
+  }
+  
+  /**
+   * Grant access to a resource
+   */
+  async grantResourceAccess(
+    integrationId: string,
+    resourceId: string,
+    data: ResourceAccessRequest
+  ): Promise<ResourceAccess | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders();
+      const response = await fetch(`${this.apiUrl}/${integrationId}/resources/${resourceId}/access`, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify(data),
+      });
+      
+      if (!response.ok) {
+        throw response;
+      }
+      
+      return await response.json();
+    } catch (error) {
+      return this.handleError(error, 'Failed to grant resource access');
+    }
+  }
+  
+  /**
+   * Helper method to check if a response is an API error
+   */
+  isApiError(response: unknown): response is ApiError {
+    return response !== null && 
+           typeof response === 'object' && 
+           'status' in response && 
+           'message' in response;
+  }
+}
+
+// Export singleton instance
+const integrationService = new IntegrationService();
+export default integrationService;


### PR DESCRIPTION
## Summary
- Implements the Integration API Service for frontend-backend communication
- Adds TypeScript interfaces for all integration data structures 
- Implements CRUD methods for team integrations (create, read, update)
- Adds methods for managing resources and sharing integrations between teams
- Implements comprehensive error handling and response parsing
- Follows singleton service pattern for consistent API access

## Test plan
- Test all API endpoints with valid and invalid data
- Verify error handling works correctly with different response types
- Confirm TypeScript type safety for integration with other components
- Test integration between frontend and backend across all endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)