### PR TITLE
Fix missing Integration import in router.py

### DIFF
--- a/backend/app/api/v1/integration/router.py
+++ b/backend/app/api/v1/integration/router.py
@@ -34,6 +34,7 @@ from app.db.session import get_async_db
 from app.models.integration import (
     AccessLevel,
     CredentialType,
+    Integration,
     IntegrationCredential,
     IntegrationType,
     ServiceResource,


### PR DESCRIPTION
## Summary
- Added missing Integration import in app/api/v1/integration/router.py
- Fixes 500 error when creating or updating integrations via the API
- This error was causing the integration creation to fail after successful OAuth flow

## Test plan
- Verify that OAuth flow now correctly creates integrations in the database
- Verify that updating integrations no longer produces 500 errors
- No changes to existing functionality - just fixing a missing import

🤖 Generated with [Claude Code](https://claude.ai/code)