### PR TITLE
Fix vite.config.ts allowedHosts issue

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,18 @@ export default defineConfig(({ mode }) => {
     VITE_ADDITIONAL_ALLOWED_HOSTS: env.VITE_ADDITIONAL_ALLOWED_HOSTS,
   });
   
+  // Extract hostnames from environment variables
+  const extractHostname = (url: string) => {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return null;
+    }
+  };
+
+  // Get ngrok hostname if available
+  const ngrokHost = env.VITE_FRONTEND_URL ? extractHostname(env.VITE_FRONTEND_URL) : null;
+
   // For development with ngrok, allow all hosts
   // This is a more permissive approach that will solve the immediate issue
   const allowedHosts = true; // Allow all hosts
@@ -30,7 +42,7 @@ export default defineConfig(({ mode }) => {
       clientPort: number;
     };
     cors: boolean;
-    allowedHosts: string[];
+    allowedHosts: string[] | boolean;
     proxy?: {
       [key: string]: {
         target: string;
@@ -52,8 +64,9 @@ export default defineConfig(({ mode }) => {
         clientPort: 5173
       },
       cors: true,
-      // Allow connections from these hosts
-      allowedHosts: typeof allowedHosts === 'boolean' ? ['localhost', '127.0.0.1'] : allowedHosts,
+      // When allowedHosts is true, keep it as true (allow all hosts)
+      // Otherwise, ensure we include both localhost and ngrok domains
+      allowedHosts,
       // Initialize proxy as empty object to satisfy TypeScript
       proxy: {} as ServerConfig['proxy']
     } as ServerConfig
@@ -74,6 +87,6 @@ export default defineConfig(({ mode }) => {
     console.log('Production mode: API proxy disabled');
   }
   
-  console.log('Allowed hosts:', allowedHosts);
+  console.log('Allowed hosts:', allowedHosts === true ? 'All hosts allowed' : allowedHosts);
   return config;
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,17 +14,18 @@ export default defineConfig(({ mode }) => {
     VITE_ADDITIONAL_ALLOWED_HOSTS: env.VITE_ADDITIONAL_ALLOWED_HOSTS,
   });
   
-  // Extract hostnames from environment variables
-  const extractHostname = (url: string) => {
-    try {
-      return new URL(url).hostname;
-    } catch {
-      return null;
-    }
-  };
-
-  // Get ngrok hostname if available
-  const ngrokHost = env.VITE_FRONTEND_URL ? extractHostname(env.VITE_FRONTEND_URL) : null;
+  // FUTURE ENHANCEMENT: If we need to extract specific domains to include instead of allowing all:
+  // 
+  // function extractHostname(url) {
+  //   try {
+  //     return new URL(url).hostname;
+  //   } catch {
+  //     return null;
+  //   }
+  // }
+  // 
+  // const ngrokHost = env.VITE_FRONTEND_URL ? extractHostname(env.VITE_FRONTEND_URL) : null;
+  // const allowedHostsList = ['localhost', '127.0.0.1', ngrokHost].filter(Boolean);
 
   // For development with ngrok, allow all hosts
   // This is a more permissive approach that will solve the immediate issue
@@ -42,7 +43,7 @@ export default defineConfig(({ mode }) => {
       clientPort: number;
     };
     cors: boolean;
-    allowedHosts: string[] | boolean;
+    allowedHosts: string[] | true;
     proxy?: {
       [key: string]: {
         target: string;


### PR DESCRIPTION
## Summary
- Fixed an issue where the allowedHosts setting in vite.config.ts was being converted to a restricted array instead of keeping the true value, which broke ngrok connections
- This fix ensures that when allowedHosts is set to true, it stays as true in the config

## Problem
When using allowedHosts = true, the configuration was incorrectly transforming this to ['localhost', '127.0.0.1'], which caused the error:
```
Blocked request. This host ("summary-locust-arriving.ngrok-free.app") is not allowed.
```

## Solution
- Updated the Vite server config to properly handle boolean allowedHosts values
- Fixed the TypeScript interface to include boolean as a valid type for allowedHosts
- Added a utility function to extract hostnames from URLs for potential future use
- Improved logging to clearly indicate when all hosts are allowed

## Testing
- Tested with ngrok to verify that the connection is now accepted
- Confirmed that the proper configuration is logged at startup

🤖 Generated with [Claude Code](https://claude.ai/code)