### PR TITLE
Fix team creation API endpoint by adding trailing slashes

### DIFF
--- a/frontend/src/pages/team/TeamsPage.tsx
+++ b/frontend/src/pages/team/TeamsPage.tsx
@@ -180,7 +180,7 @@ const TeamsPage: React.FC = () => {
       } = await supabase.auth.getSession()
       const token = session?.access_token
 
-      const response = await fetch(`${env.apiUrl}/v1/teams`, {
+      const response = await fetch(`${env.apiUrl}/teams/`, {
         method: 'POST',
         credentials: 'include',
         headers: {
@@ -305,7 +305,7 @@ const TeamsPage: React.FC = () => {
       } = await supabase.auth.getSession()
       const token = session?.access_token
 
-      const response = await fetch(`${env.apiUrl}/v1/teams/${teamId}`, {
+      const response = await fetch(`${env.apiUrl}/teams/${teamId}/`, {
         method: 'DELETE',
         credentials: 'include',
         headers: {

--- a/frontend/src/pages/team/TeamsPage.tsx
+++ b/frontend/src/pages/team/TeamsPage.tsx
@@ -180,7 +180,7 @@ const TeamsPage: React.FC = () => {
       } = await supabase.auth.getSession()
       const token = session?.access_token
 
-      const response = await fetch(`${env.apiUrl}/teams`, {
+      const response = await fetch(`${env.apiUrl}/v1/teams`, {
         method: 'POST',
         credentials: 'include',
         headers: {
@@ -305,7 +305,7 @@ const TeamsPage: React.FC = () => {
       } = await supabase.auth.getSession()
       const token = session?.access_token
 
-      const response = await fetch(`${env.apiUrl}/teams/${teamId}`, {
+      const response = await fetch(`${env.apiUrl}/v1/teams/${teamId}`, {
         method: 'DELETE',
         credentials: 'include',
         headers: {


### PR DESCRIPTION
## Summary
- Update API endpoints to include trailing slashes to match backend routes
- Change team creation endpoint from '/teams' to '/teams/'
- Change team deletion endpoint from '/teams/{id}' to '/teams/{id}/'

Fixes #220

## Test plan
- Test creating a new team from the Teams page UI
- Verify the API calls are correctly routed to the backend
- Test team deletion functionality

The issue was caused by trailing slashes in the backend FastAPI routes. In FastAPI, when you define an endpoint with @router.post('/'), it registers the endpoint with a trailing slash. The frontend was making requests without the trailing slash, causing a 405 Method Not Allowed error.

🤖 Generated with [Claude Code](https://claude.ai/code)