### PR TITLE
Add cross-resource analyses history page

### DIFF
--- a/backend/scripts/check_reports.py
+++ b/backend/scripts/check_reports.py
@@ -17,8 +17,8 @@ import asyncio
 import logging
 import os
 import sys
-from datetime import datetime
-from typing import Dict, List, Optional
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Set, Tuple
 from uuid import UUID
 
 # Add the backend directory to the Python path
@@ -26,6 +26,7 @@ backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, backend_dir)
 
 import sqlalchemy as sa
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,9 @@ import {
 // Team Pages
 import { TeamsPage, TeamDetailPage, TeamMembersPage } from './pages/team'
 
+// Report Pages
+import { CrossResourceReportsPage } from './pages/reports'
+
 // Integration Pages
 import {
   IntegrationsPage,
@@ -155,6 +158,18 @@ function App() {
                   <ProtectedRoute>
                     <AppLayout>
                       <Analytics />
+                    </AppLayout>
+                  </ProtectedRoute>
+                }
+              />
+
+              {/* Cross-Resource Reports History Page */}
+              <Route
+                path="/dashboard/teams/:teamId/reports"
+                element={
+                  <ProtectedRoute>
+                    <AppLayout>
+                      <CrossResourceReportsPage />
                     </AppLayout>
                   </ProtectedRoute>
                 }

--- a/frontend/src/__tests__/pages/reports/CrossResourceReportsPage.test.tsx
+++ b/frontend/src/__tests__/pages/reports/CrossResourceReportsPage.test.tsx
@@ -1,21 +1,22 @@
-import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
-import CrossResourceReportsPage from '../../../pages/reports/CrossResourceReportsPage';
-import integrationService from '../../../lib/integrationService';
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import CrossResourceReportsPage from '../../../pages/reports/CrossResourceReportsPage'
+import integrationService from '../../../lib/integrationService'
+import { ChakraProvider } from '@chakra-ui/react'
 
 // Mock the integration service
 jest.mock('../../../lib/integrationService', () => ({
   getCrossResourceReports: jest.fn(),
-  isApiError: jest.fn((response) => 'status' in response && typeof response.status === 'number'),
-}));
+  isApiError: jest.fn(response => 'status' in response && typeof response.status === 'number')
+}))
 
 // Mock for useParams
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: () => ({ teamId: 'team-123' }),
-}));
+}))
 
 const mockReports = {
   items: [
@@ -44,117 +45,103 @@ const mockReports = {
     },
   ],
   total: 2,
-};
+}
+
+const renderWithProviders = (ui) => {
+  return render(
+    <ChakraProvider>
+      <MemoryRouter>
+        {ui}
+      </MemoryRouter>
+    </ChakraProvider>
+  )
+}
 
 describe('CrossResourceReportsPage', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    (integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue(mockReports);
-  });
+    jest.clearAllMocks()
+    ;(integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue(mockReports)
+  })
 
   it('renders the page title correctly', async () => {
-    render(
-      <MemoryRouter>
-        <CrossResourceReportsPage />
-      </MemoryRouter>
-    );
+    renderWithProviders(<CrossResourceReportsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Cross-Resource Analysis Reports')).toBeInTheDocument();
-    });
-  });
+      expect(screen.getByText('Cross-Resource Analysis Reports')).toBeInTheDocument()
+    })
+  })
 
   it('displays loading state initially', () => {
-    render(
-      <MemoryRouter>
-        <CrossResourceReportsPage />
-      </MemoryRouter>
-    );
-
-    expect(screen.getByRole('progressbar')).toBeInTheDocument();
-  });
+    renderWithProviders(<CrossResourceReportsPage />)
+    
+    expect(screen.getByRole('status')).toBeInTheDocument() // Chakra spinner
+  })
 
   it('fetches and displays report data', async () => {
-    render(
-      <MemoryRouter>
-        <CrossResourceReportsPage />
-      </MemoryRouter>
-    );
+    renderWithProviders(<CrossResourceReportsPage />)
 
     await waitFor(() => {
-      expect(integrationService.getCrossResourceReports).toHaveBeenCalledWith('team-123', 1, 10);
-    });
+      expect(integrationService.getCrossResourceReports).toHaveBeenCalledWith(
+        'team-123',
+        1,
+        10
+      )
+    })
 
-    expect(await screen.findByText('Weekly Team Analysis')).toBeInTheDocument();
-    expect(screen.getByText('Project X Kickoff Analysis')).toBeInTheDocument();
-    expect(screen.getByText('John Doe')).toBeInTheDocument();
-    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
-  });
+    expect(await screen.findByText('Weekly Team Analysis')).toBeInTheDocument()
+    expect(screen.getByText('Project X Kickoff Analysis')).toBeInTheDocument()
+    expect(screen.getByText('John Doe')).toBeInTheDocument()
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument()
+  })
 
-  it('shows correct status chips', async () => {
-    render(
-      <MemoryRouter>
-        <CrossResourceReportsPage />
-      </MemoryRouter>
-    );
+  it('shows correct status badges', async () => {
+    renderWithProviders(<CrossResourceReportsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Completed')).toBeInTheDocument();
-      expect(screen.getByText('In Progress')).toBeInTheDocument();
-    });
-  });
+      expect(screen.getByText('Completed')).toBeInTheDocument()
+      expect(screen.getByText('In Progress')).toBeInTheDocument()
+    })
+  })
 
   it('displays error message when API call fails', async () => {
     const errorResponse = {
       status: 500,
       message: 'Server error',
-    };
+    }
     
-    (integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue(errorResponse);
+    ;(integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue(errorResponse)
 
-    render(
-      <MemoryRouter>
-        <CrossResourceReportsPage />
-      </MemoryRouter>
-    );
+    renderWithProviders(<CrossResourceReportsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Error loading reports: Server error')).toBeInTheDocument();
-    });
-  });
+      expect(screen.getByText('Error loading reports: Server error')).toBeInTheDocument()
+    })
+  })
 
   it('displays empty state when no reports are found', async () => {
-    (integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue({ 
+    ;(integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue({ 
       items: [], 
       total: 0 
-    });
+    })
 
-    render(
-      <MemoryRouter>
-        <CrossResourceReportsPage />
-      </MemoryRouter>
-    );
+    renderWithProviders(<CrossResourceReportsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('No cross-resource reports found')).toBeInTheDocument();
-      expect(screen.getByText('Create a new analysis to generate insights across multiple resources.')).toBeInTheDocument();
-    });
-  });
+      expect(screen.getByText('No cross-resource reports found')).toBeInTheDocument()
+      expect(screen.getByText('Create a new analysis to generate insights across multiple resources.')).toBeInTheDocument()
+    })
+  })
 
   it('handles pagination correctly', async () => {
-    render(
-      <MemoryRouter>
-        <CrossResourceReportsPage />
-      </MemoryRouter>
-    );
+    renderWithProviders(<CrossResourceReportsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Weekly Team Analysis')).toBeInTheDocument();
-    });
+      expect(screen.getByText('Weekly Team Analysis')).toBeInTheDocument()
+    })
 
     // Mock for different page
-    (integrationService.getCrossResourceReports as jest.Mock).mockClear();
-    (integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue({
+    ;(integrationService.getCrossResourceReports as jest.Mock).mockClear()
+    ;(integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue({
       items: [
         {
           id: 'report-3',
@@ -169,36 +156,48 @@ describe('CrossResourceReportsPage', () => {
         },
       ],
       total: 3,
-    });
+    })
 
     // Find and click the next page button
-    const nextPageButton = screen.getByRole('button', { name: /next page/i });
-    userEvent.click(nextPageButton);
+    const nextPageButton = screen.getByRole('button', { name: /next/i })
+    userEvent.click(nextPageButton)
 
     await waitFor(() => {
       // Check that the service was called with page 2
-      expect(integrationService.getCrossResourceReports).toHaveBeenCalledWith('team-123', 2, 10);
-    });
-  });
+      expect(integrationService.getCrossResourceReports).toHaveBeenCalledWith(
+        'team-123',
+        2,
+        10
+      )
+    })
+  })
 
   it('has correct links to create new analysis and view reports', async () => {
-    render(
-      <MemoryRouter>
-        <CrossResourceReportsPage />
-      </MemoryRouter>
-    );
+    renderWithProviders(<CrossResourceReportsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('Weekly Team Analysis')).toBeInTheDocument();
-    });
+      expect(screen.getByText('Weekly Team Analysis')).toBeInTheDocument()
+    })
 
     // Check create new analysis button
-    const createButton = screen.getByRole('link', { name: /create new analysis/i });
-    expect(createButton).toHaveAttribute('href', '/dashboard/integrations/create-analysis/team-123');
+    const createButton = screen.getByRole('link', {
+      name: /create new analysis/i,
+    })
+    expect(createButton).toHaveAttribute(
+      'href',
+      '/dashboard/integrations/create-analysis/team-123'
+    )
 
-    // Check view report links
-    const viewButtons = screen.getAllByRole('link', { name: /view report/i });
-    expect(viewButtons[0]).toHaveAttribute('href', '/dashboard/integrations/team-analysis/report-1');
-    expect(viewButtons[1]).toHaveAttribute('href', '/dashboard/integrations/team-analysis/report-2');
-  });
-});
+    // Check view report button - there should be one per report
+    const viewButtons = screen.getAllByLabelText('View Report')
+    expect(viewButtons).toHaveLength(2)
+    expect(viewButtons[0]).toHaveAttribute(
+      'href',
+      '/dashboard/integrations/team-analysis/report-1'
+    )
+    expect(viewButtons[1]).toHaveAttribute(
+      'href',
+      '/dashboard/integrations/team-analysis/report-2'
+    )
+  })
+})

--- a/frontend/src/__tests__/pages/reports/CrossResourceReportsPage.test.tsx
+++ b/frontend/src/__tests__/pages/reports/CrossResourceReportsPage.test.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import CrossResourceReportsPage from '../../../pages/reports/CrossResourceReportsPage';
+import integrationService from '../../../lib/integrationService';
+
+// Mock the integration service
+jest.mock('../../../lib/integrationService', () => ({
+  getCrossResourceReports: jest.fn(),
+  isApiError: jest.fn((response) => 'status' in response && typeof response.status === 'number'),
+}));
+
+// Mock for useParams
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ teamId: 'team-123' }),
+}));
+
+const mockReports = {
+  items: [
+    {
+      id: 'report-1',
+      title: 'Weekly Team Analysis',
+      description: 'Analysis of team activity for the past week',
+      created_at: '2025-04-15T10:30:00Z',
+      status: 'completed',
+      resource_count: 3,
+      created_by: {
+        id: 'user-1',
+        name: 'John Doe',
+      },
+    },
+    {
+      id: 'report-2',
+      title: 'Project X Kickoff Analysis',
+      created_at: '2025-04-10T09:15:00Z',
+      status: 'in_progress',
+      resource_count: 5,
+      created_by: {
+        id: 'user-2',
+        email: 'jane@example.com',
+      },
+    },
+  ],
+  total: 2,
+};
+
+describe('CrossResourceReportsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue(mockReports);
+  });
+
+  it('renders the page title correctly', async () => {
+    render(
+      <MemoryRouter>
+        <CrossResourceReportsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Cross-Resource Analysis Reports')).toBeInTheDocument();
+    });
+  });
+
+  it('displays loading state initially', () => {
+    render(
+      <MemoryRouter>
+        <CrossResourceReportsPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('fetches and displays report data', async () => {
+    render(
+      <MemoryRouter>
+        <CrossResourceReportsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(integrationService.getCrossResourceReports).toHaveBeenCalledWith('team-123', 1, 10);
+    });
+
+    expect(await screen.findByText('Weekly Team Analysis')).toBeInTheDocument();
+    expect(screen.getByText('Project X Kickoff Analysis')).toBeInTheDocument();
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+  });
+
+  it('shows correct status chips', async () => {
+    render(
+      <MemoryRouter>
+        <CrossResourceReportsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Completed')).toBeInTheDocument();
+      expect(screen.getByText('In Progress')).toBeInTheDocument();
+    });
+  });
+
+  it('displays error message when API call fails', async () => {
+    const errorResponse = {
+      status: 500,
+      message: 'Server error',
+    };
+    
+    (integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue(errorResponse);
+
+    render(
+      <MemoryRouter>
+        <CrossResourceReportsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Error loading reports: Server error')).toBeInTheDocument();
+    });
+  });
+
+  it('displays empty state when no reports are found', async () => {
+    (integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue({ 
+      items: [], 
+      total: 0 
+    });
+
+    render(
+      <MemoryRouter>
+        <CrossResourceReportsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No cross-resource reports found')).toBeInTheDocument();
+      expect(screen.getByText('Create a new analysis to generate insights across multiple resources.')).toBeInTheDocument();
+    });
+  });
+
+  it('handles pagination correctly', async () => {
+    render(
+      <MemoryRouter>
+        <CrossResourceReportsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Weekly Team Analysis')).toBeInTheDocument();
+    });
+
+    // Mock for different page
+    (integrationService.getCrossResourceReports as jest.Mock).mockClear();
+    (integrationService.getCrossResourceReports as jest.Mock).mockResolvedValue({
+      items: [
+        {
+          id: 'report-3',
+          title: 'Different Page Report',
+          created_at: '2025-03-20T15:45:00Z',
+          status: 'pending',
+          resource_count: 2,
+          created_by: {
+            id: 'user-3',
+            name: 'Bob Smith',
+          },
+        },
+      ],
+      total: 3,
+    });
+
+    // Find and click the next page button
+    const nextPageButton = screen.getByRole('button', { name: /next page/i });
+    userEvent.click(nextPageButton);
+
+    await waitFor(() => {
+      // Check that the service was called with page 2
+      expect(integrationService.getCrossResourceReports).toHaveBeenCalledWith('team-123', 2, 10);
+    });
+  });
+
+  it('has correct links to create new analysis and view reports', async () => {
+    render(
+      <MemoryRouter>
+        <CrossResourceReportsPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Weekly Team Analysis')).toBeInTheDocument();
+    });
+
+    // Check create new analysis button
+    const createButton = screen.getByRole('link', { name: /create new analysis/i });
+    expect(createButton).toHaveAttribute('href', '/dashboard/integrations/create-analysis/team-123');
+
+    // Check view report links
+    const viewButtons = screen.getAllByRole('link', { name: /view report/i });
+    expect(viewButtons[0]).toHaveAttribute('href', '/dashboard/integrations/team-analysis/report-1');
+    expect(viewButtons[1]).toHaveAttribute('href', '/dashboard/integrations/team-analysis/report-2');
+  });
+});

--- a/frontend/src/__tests__/pages/reports/CrossResourceReportsPage.test.tsx
+++ b/frontend/src/__tests__/pages/reports/CrossResourceReportsPage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import CrossResourceReportsPage from '../../../pages/reports/CrossResourceReportsPage';
 import integrationService from '../../../lib/integrationService';
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   FiExternalLink,
   FiUser,
   FiBox,
+  FiFileText,
 } from 'react-icons/fi'
 import useAuth from '../../context/useAuth'
 
@@ -180,7 +181,7 @@ const Sidebar = ({ onClose, ...rest }: SidebarProps) => {
               textTransform="uppercase"
               color="gray.500"
             >
-              Integrations
+              Integrations & Analysis
             </Text>
           </Box>
 
@@ -200,9 +201,21 @@ const Sidebar = ({ onClose, ...rest }: SidebarProps) => {
               icon={FiBarChart2}
               isActive={isActivePath('/dashboard/analytics')}
             >
-              Analysis
+              Analysis Hub
             </NavItem>
           </ListItem>
+          
+          {currentTeam && (
+            <ListItem>
+              <NavItem
+                to={`/dashboard/teams/${currentTeam.id}/reports`}
+                icon={FiFileText}
+                isActive={isActivePath(`/dashboard/teams/${currentTeam.id}/reports`)}
+              >
+                Analysis Reports
+              </NavItem>
+            </ListItem>
+          )}
 
           <Divider my={3} />
 

--- a/frontend/src/lib/integrationService.ts
+++ b/frontend/src/lib/integrationService.ts
@@ -1143,6 +1143,59 @@ class IntegrationService {
       return this.handleError(error, 'Failed to get cross-resource report')
     }
   }
+
+  /**
+   * Get cross-resource reports history for a team
+   * @param teamId Team UUID
+   * @param page Page number (optional, defaults to 1)
+   * @param limit Number of reports per page (optional, defaults to 10)
+   * @param status Filter by report status (optional)
+   */
+  async getCrossResourceReports(
+    teamId: string,
+    page: number = 1,
+    limit: number = 10,
+    status?: string
+  ): Promise<Record<string, unknown> | ApiError> {
+    try {
+      const headers = await this.getAuthHeaders()
+      let url = `${REPORTS_API_BASE}/${teamId}/cross-resource-reports?page=${page}&limit=${limit}`
+      
+      if (status) {
+        url += `&status=${status}`
+      }
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          ...headers,
+          Accept: 'application/json',
+        },
+        credentials: 'include',
+      })
+
+      if (!response.ok) {
+        let errorDetail = ''
+        try {
+          const errorText = await response.text()
+          const errorJson = JSON.parse(errorText)
+          errorDetail = errorJson.detail || errorText
+        } catch {
+          errorDetail = response.statusText
+        }
+
+        return {
+          status: response.status,
+          message: `Failed to retrieve reports: ${response.status} ${response.statusText}`,
+          detail: errorDetail,
+        }
+      }
+
+      return await response.json()
+    } catch (error) {
+      return this.handleError(error, 'Failed to get cross-resource reports')
+    }
+  }
 }
 
 // Export singleton instance

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -92,7 +92,7 @@ const Analytics: React.FC = () => {
             )
             
             if (!integrationService.isApiError(response) && response.items) {
-              const teamReports = response.items.map((report: any) => ({
+              const teamReports = response.items.map((report: Record<string, unknown>) => ({
                 id: report.id,
                 title: report.title || 'Untitled Report',
                 date: report.created_at,
@@ -243,7 +243,7 @@ const Analytics: React.FC = () => {
   const formatDate = (dateString: string) => {
     try {
       return format(new Date(dateString), 'MMM d, yyyy')
-    } catch (e) {
+    } catch {
       return dateString
     }
   }

--- a/frontend/src/pages/reports/CrossResourceReportsPage.tsx
+++ b/frontend/src/pages/reports/CrossResourceReportsPage.tsx
@@ -1,265 +1,299 @@
-import React, { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import React, { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
 import {
   Box,
   Button,
   Card,
-  CardContent,
-  Typography,
-  CircularProgress,
-  Paper,
+  CardBody,
+  Text,
+  Spinner,
   Table,
-  TableBody,
-  TableCell,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
   TableContainer,
-  TableHead,
-  TableRow,
-  TablePagination,
-  Chip,
-  Tooltip,
+  Flex,
+  VStack,
+  HStack,
+  Badge,
   IconButton,
-} from '@mui/material';
-import { Refresh as RefreshIcon, Visibility as ViewIcon } from '@mui/icons-material';
-import { format } from 'date-fns';
-import PageTitle from '../../components/layout/PageTitle';
-import integrationService from '../../lib/integrationService';
-import Breadcrumb from '../../components/layout/Breadcrumb';
+  Tooltip,
+  Select,
+  useColorModeValue,
+} from '@chakra-ui/react'
+import {
+  FiRefreshCw,
+  FiEye,
+} from 'react-icons/fi'
+import { format } from 'date-fns'
+import PageTitle from '../../components/layout/PageTitle'
+import integrationService from '../../lib/integrationService'
 
 // Status styles
-const getStatusStyles = (status: string): { color: 'success' | 'warning' | 'info' | 'error' | 'default', label: string } => {
+const getStatusStyles = (
+  status: string
+): {
+  colorScheme: 'green' | 'yellow' | 'blue' | 'red' | 'gray'
+  label: string
+} => {
   switch (status.toLowerCase()) {
     case 'completed':
-      return { color: 'success', label: 'Completed' };
+      return { colorScheme: 'green', label: 'Completed' }
     case 'pending':
-      return { color: 'warning', label: 'Pending' };
+      return { colorScheme: 'yellow', label: 'Pending' }
     case 'in_progress':
-      return { color: 'info', label: 'In Progress' };
+      return { colorScheme: 'blue', label: 'In Progress' }
     case 'failed':
-      return { color: 'error', label: 'Failed' };
+      return { colorScheme: 'red', label: 'Failed' }
     default:
-      return { color: 'default', label: status };
+      return { colorScheme: 'gray', label: status }
   }
-};
+}
 
 interface CrossResourceReport {
-  id: string;
-  title: string;
-  created_at: string;
-  status: string;
-  resource_count: number;
-  description?: string;
+  id: string
+  title: string
+  created_at: string
+  status: string
+  resource_count: number
+  description?: string
   created_by: {
-    id: string;
-    name?: string;
-    email?: string;
-  };
+    id: string
+    name?: string
+    email?: string
+  }
 }
 
 const CrossResourceReportsPage: React.FC = () => {
-  const { teamId } = useParams<{ teamId: string }>();
-  const [reports, setReports] = useState<CrossResourceReport[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-  const [page, setPage] = useState<number>(0);
-  const [totalCount, setTotalCount] = useState<number>(0);
-  const [rowsPerPage, setRowsPerPage] = useState<number>(10);
-  const [refreshing, setRefreshing] = useState<boolean>(false);
+  const { teamId } = useParams<{ teamId: string }>()
+  const [reports, setReports] = useState<CrossResourceReport[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const [page, setPage] = useState<number>(0)
+  const [totalCount, setTotalCount] = useState<number>(0)
+  const [rowsPerPage, setRowsPerPage] = useState<number>(10)
+  const [refreshing, setRefreshing] = useState<boolean>(false)
+  
+  const errorBgColor = useColorModeValue('red.50', 'red.900')
+  const errorTextColor = useColorModeValue('red.600', 'red.200')
 
   const fetchReports = async () => {
-    if (!teamId) return;
-    
-    setLoading(true);
-    setError(null);
-    
+    if (!teamId) return
+
+    setLoading(true)
+    setError(null)
+
     try {
       const response = await integrationService.getCrossResourceReports(
         teamId,
         page + 1, // API uses 1-based indexing
         rowsPerPage
-      );
-      
+      )
+
       if (integrationService.isApiError(response)) {
-        setError(`Error loading reports: ${response.message}`);
-        setReports([]);
+        setError(`Error loading reports: ${response.message}`)
+        setReports([])
       } else {
-        setReports(response.items || []);
-        setTotalCount(response.total || 0);
+        setReports(response.items || [])
+        setTotalCount(response.total || 0)
       }
     } catch (err) {
-      setError('Failed to load cross-resource reports');
-      console.error('Error fetching reports:', err);
+      setError('Failed to load cross-resource reports')
+      console.error('Error fetching reports:', err)
     } finally {
-      setLoading(false);
-      setRefreshing(false);
+      setLoading(false)
+      setRefreshing(false)
     }
-  };
+  }
 
   useEffect(() => {
-    fetchReports();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamId, page, rowsPerPage]);
+    fetchReports()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teamId, page, rowsPerPage])
 
-  const handleChangePage = (event: unknown, newPage: number) => {
-    setPage(newPage);
-  };
-
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
-  };
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10))
+    setPage(0)
+  }
 
   const handleRefresh = () => {
-    setRefreshing(true);
-    fetchReports();
-  };
+    setRefreshing(true)
+    fetchReports()
+  }
+  
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage)
+  }
 
   const formatDate = (dateString: string) => {
     try {
-      return format(new Date(dateString), 'MMM d, yyyy h:mm a');
+      return format(new Date(dateString), 'MMM d, yyyy h:mm a')
     } catch {
-      return dateString;
+      return dateString
     }
-  };
+  }
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Breadcrumb
-        items={[
-          { label: 'Dashboard', to: '/dashboard' },
-          { label: 'Teams', to: '/dashboard/teams' },
-          { label: 'Cross-Resource Reports', to: '#' },
-        ]}
-      />
-      
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+    <Box p={5}>
+      <Flex justifyContent="space-between" alignItems="center" mb={6}>
         <PageTitle title="Cross-Resource Analysis Reports" />
         
-        <Box sx={{ display: 'flex', gap: 2 }}>
+        <HStack spacing={3}>
           <Button
-            variant="outlined"
-            color="primary"
-            startIcon={<RefreshIcon />}
+            variant="outline"
+            colorScheme="blue"
+            leftIcon={<FiRefreshCw />}
             onClick={handleRefresh}
-            disabled={refreshing}
+            isLoading={refreshing}
+            loadingText="Refreshing..."
           >
-            {refreshing ? 'Refreshing...' : 'Refresh'}
+            Refresh
           </Button>
           
           <Button
-            variant="contained"
-            color="primary"
-            component={Link}
+            colorScheme="blue"
+            as={Link}
             to={`/dashboard/integrations/create-analysis/${teamId}`}
           >
             Create New Analysis
           </Button>
-        </Box>
-      </Box>
+        </HStack>
+      </Flex>
 
       {loading && !refreshing ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
-          <CircularProgress />
-        </Box>
+        <Flex justify="center" align="center" my={10}>
+          <Spinner size="xl" thickness="4px" color="blue.500" />
+        </Flex>
       ) : error ? (
-        <Card variant="outlined" sx={{ mb: 3, bgcolor: 'error.light', color: 'error.contrastText' }}>
-          <CardContent>
-            <Typography variant="h6">Error</Typography>
-            <Typography>{error}</Typography>
-          </CardContent>
+        <Card mb={5} bg={errorBgColor} color={errorTextColor}>
+          <CardBody>
+            <Text fontWeight="bold">Error</Text>
+            <Text>{error}</Text>
+          </CardBody>
         </Card>
       ) : reports.length === 0 ? (
-        <Card variant="outlined" sx={{ mb: 3 }}>
-          <CardContent>
-            <Typography variant="h6" align="center" sx={{ my: 3 }}>
+        <Card variant="outline" mb={5}>
+          <CardBody textAlign="center" py={10}>
+            <Text fontSize="lg" fontWeight="semibold" mb={3}>
               No cross-resource reports found
-            </Typography>
-            <Typography align="center" color="textSecondary">
+            </Text>
+            <Text color="gray.500" mb={5}>
               Create a new analysis to generate insights across multiple resources.
-            </Typography>
-            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3 }}>
-              <Button
-                variant="contained"
-                color="primary"
-                component={Link}
-                to={`/dashboard/integrations/create-analysis/${teamId}`}
-              >
-                Create Analysis
-              </Button>
-            </Box>
-          </CardContent>
+            </Text>
+            <Button
+              colorScheme="blue"
+              as={Link}
+              to={`/dashboard/integrations/create-analysis/${teamId}`}
+            >
+              Create Analysis
+            </Button>
+          </CardBody>
         </Card>
       ) : (
         <>
-          <TableContainer component={Paper}>
-            <Table sx={{ minWidth: 650 }}>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Title</TableCell>
-                  <TableCell>Created</TableCell>
-                  <TableCell>Status</TableCell>
-                  <TableCell>Resources</TableCell>
-                  <TableCell>Created By</TableCell>
-                  <TableCell align="right">Actions</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
+          <TableContainer borderWidth="1px" borderRadius="md" mb={5}>
+            <Table variant="simple">
+              <Thead>
+                <Tr>
+                  <Th>Title</Th>
+                  <Th>Created</Th>
+                  <Th>Status</Th>
+                  <Th>Resources</Th>
+                  <Th>Created By</Th>
+                  <Th isNumeric>Actions</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
                 {reports.map((report) => {
-                  const statusInfo = getStatusStyles(report.status);
+                  const statusInfo = getStatusStyles(report.status)
                   return (
-                    <TableRow key={report.id} hover>
-                      <TableCell component="th" scope="row">
-                        <Typography variant="body1" fontWeight="medium">
-                          {report.title}
-                        </Typography>
-                        {report.description && (
-                          <Typography variant="body2" color="textSecondary" noWrap sx={{ maxWidth: 300 }}>
-                            {report.description}
-                          </Typography>
-                        )}
-                      </TableCell>
-                      <TableCell>{formatDate(report.created_at)}</TableCell>
-                      <TableCell>
-                        <Chip 
-                          label={statusInfo.label} 
-                          color={statusInfo.color} 
-                          size="small" 
-                          variant="filled" 
-                        />
-                      </TableCell>
-                      <TableCell>{report.resource_count}</TableCell>
-                      <TableCell>
-                        {report.created_by?.name || report.created_by?.email || 'Unknown user'}
-                      </TableCell>
-                      <TableCell align="right">
-                        <Tooltip title="View Report">
-                          <IconButton 
-                            component={Link} 
+                    <Tr key={report.id}>
+                      <Td>
+                        <VStack align="start" spacing={0}>
+                          <Text fontWeight="medium">{report.title}</Text>
+                          {report.description && (
+                            <Text fontSize="sm" color="gray.500" noOfLines={1}>
+                              {report.description}
+                            </Text>
+                          )}
+                        </VStack>
+                      </Td>
+                      <Td>{formatDate(report.created_at)}</Td>
+                      <Td>
+                        <Badge colorScheme={statusInfo.colorScheme} variant="subtle" px={2} py={1} borderRadius="full">
+                          {statusInfo.label}
+                        </Badge>
+                      </Td>
+                      <Td>{report.resource_count}</Td>
+                      <Td>
+                        {report.created_by?.name ||
+                          report.created_by?.email ||
+                          'Unknown user'}
+                      </Td>
+                      <Td isNumeric>
+                        <Tooltip label="View Report">
+                          <IconButton
+                            as={Link}
                             to={`/dashboard/integrations/team-analysis/${report.id}`}
-                            color="primary"
-                          >
-                            <ViewIcon />
-                          </IconButton>
+                            icon={<FiEye />}
+                            aria-label="View Report"
+                            colorScheme="blue"
+                            variant="ghost"
+                            size="sm"
+                          />
                         </Tooltip>
-                      </TableCell>
-                    </TableRow>
-                  );
+                      </Td>
+                    </Tr>
+                  )
                 })}
-              </TableBody>
+              </Tbody>
             </Table>
           </TableContainer>
-          <TablePagination
-            rowsPerPageOptions={[5, 10, 25]}
-            component="div"
-            count={totalCount}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={handleChangePage}
-            onRowsPerPageChange={handleChangeRowsPerPage}
-          />
+          
+          <Flex justify="space-between" align="center">
+            <HStack>
+              <Text fontSize="sm">Rows per page:</Text>
+              <Select 
+                size="sm" 
+                width="70px"
+                value={rowsPerPage}
+                onChange={handleChangeRowsPerPage}
+              >
+                <option value="5">5</option>
+                <option value="10">10</option>
+                <option value="25">25</option>
+              </Select>
+            </HStack>
+            
+            <HStack>
+              <Text fontSize="sm">
+                {page * rowsPerPage + 1}-
+                {Math.min((page + 1) * rowsPerPage, totalCount)} of {totalCount}
+              </Text>
+              <Button
+                size="sm"
+                onClick={() => handlePageChange(page - 1)}
+                isDisabled={page === 0}
+                variant="ghost"
+              >
+                Previous
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => handlePageChange(page + 1)}
+                isDisabled={(page + 1) * rowsPerPage >= totalCount}
+                variant="ghost"
+              >
+                Next
+              </Button>
+            </HStack>
+          </Flex>
         </>
       )}
     </Box>
-  );
-};
+  )
+}
 
-export default CrossResourceReportsPage;
+export default CrossResourceReportsPage

--- a/frontend/src/pages/reports/CrossResourceReportsPage.tsx
+++ b/frontend/src/pages/reports/CrossResourceReportsPage.tsx
@@ -26,7 +26,7 @@ import integrationService from '../../lib/integrationService';
 import Breadcrumb from '../../components/layout/Breadcrumb';
 
 // Status styles
-const getStatusStyles = (status: string) => {
+const getStatusStyles = (status: string): { color: 'success' | 'warning' | 'info' | 'error' | 'default', label: string } => {
   switch (status.toLowerCase()) {
     case 'completed':
       return { color: 'success', label: 'Completed' };
@@ -96,6 +96,7 @@ const CrossResourceReportsPage: React.FC = () => {
 
   useEffect(() => {
     fetchReports();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [teamId, page, rowsPerPage]);
 
   const handleChangePage = (event: unknown, newPage: number) => {
@@ -115,7 +116,7 @@ const CrossResourceReportsPage: React.FC = () => {
   const formatDate = (dateString: string) => {
     try {
       return format(new Date(dateString), 'MMM d, yyyy h:mm a');
-    } catch (e) {
+    } catch {
       return dateString;
     }
   };
@@ -220,7 +221,7 @@ const CrossResourceReportsPage: React.FC = () => {
                       <TableCell>
                         <Chip 
                           label={statusInfo.label} 
-                          color={statusInfo.color as any} 
+                          color={statusInfo.color} 
                           size="small" 
                           variant="filled" 
                         />

--- a/frontend/src/pages/reports/CrossResourceReportsPage.tsx
+++ b/frontend/src/pages/reports/CrossResourceReportsPage.tsx
@@ -1,0 +1,264 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Typography,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TablePagination,
+  Chip,
+  Tooltip,
+  IconButton,
+} from '@mui/material';
+import { Refresh as RefreshIcon, Visibility as ViewIcon } from '@mui/icons-material';
+import { format } from 'date-fns';
+import PageTitle from '../../components/layout/PageTitle';
+import integrationService from '../../lib/integrationService';
+import Breadcrumb from '../../components/layout/Breadcrumb';
+
+// Status styles
+const getStatusStyles = (status: string) => {
+  switch (status.toLowerCase()) {
+    case 'completed':
+      return { color: 'success', label: 'Completed' };
+    case 'pending':
+      return { color: 'warning', label: 'Pending' };
+    case 'in_progress':
+      return { color: 'info', label: 'In Progress' };
+    case 'failed':
+      return { color: 'error', label: 'Failed' };
+    default:
+      return { color: 'default', label: status };
+  }
+};
+
+interface CrossResourceReport {
+  id: string;
+  title: string;
+  created_at: string;
+  status: string;
+  resource_count: number;
+  description?: string;
+  created_by: {
+    id: string;
+    name?: string;
+    email?: string;
+  };
+}
+
+const CrossResourceReportsPage: React.FC = () => {
+  const { teamId } = useParams<{ teamId: string }>();
+  const [reports, setReports] = useState<CrossResourceReport[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState<number>(0);
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [rowsPerPage, setRowsPerPage] = useState<number>(10);
+  const [refreshing, setRefreshing] = useState<boolean>(false);
+
+  const fetchReports = async () => {
+    if (!teamId) return;
+    
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const response = await integrationService.getCrossResourceReports(
+        teamId,
+        page + 1, // API uses 1-based indexing
+        rowsPerPage
+      );
+      
+      if (integrationService.isApiError(response)) {
+        setError(`Error loading reports: ${response.message}`);
+        setReports([]);
+      } else {
+        setReports(response.items || []);
+        setTotalCount(response.total || 0);
+      }
+    } catch (err) {
+      setError('Failed to load cross-resource reports');
+      console.error('Error fetching reports:', err);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchReports();
+  }, [teamId, page, rowsPerPage]);
+
+  const handleChangePage = (event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    fetchReports();
+  };
+
+  const formatDate = (dateString: string) => {
+    try {
+      return format(new Date(dateString), 'MMM d, yyyy h:mm a');
+    } catch (e) {
+      return dateString;
+    }
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Breadcrumb
+        items={[
+          { label: 'Dashboard', to: '/dashboard' },
+          { label: 'Teams', to: '/dashboard/teams' },
+          { label: 'Cross-Resource Reports', to: '#' },
+        ]}
+      />
+      
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <PageTitle title="Cross-Resource Analysis Reports" />
+        
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Button
+            variant="outlined"
+            color="primary"
+            startIcon={<RefreshIcon />}
+            onClick={handleRefresh}
+            disabled={refreshing}
+          >
+            {refreshing ? 'Refreshing...' : 'Refresh'}
+          </Button>
+          
+          <Button
+            variant="contained"
+            color="primary"
+            component={Link}
+            to={`/dashboard/integrations/create-analysis/${teamId}`}
+          >
+            Create New Analysis
+          </Button>
+        </Box>
+      </Box>
+
+      {loading && !refreshing ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : error ? (
+        <Card variant="outlined" sx={{ mb: 3, bgcolor: 'error.light', color: 'error.contrastText' }}>
+          <CardContent>
+            <Typography variant="h6">Error</Typography>
+            <Typography>{error}</Typography>
+          </CardContent>
+        </Card>
+      ) : reports.length === 0 ? (
+        <Card variant="outlined" sx={{ mb: 3 }}>
+          <CardContent>
+            <Typography variant="h6" align="center" sx={{ my: 3 }}>
+              No cross-resource reports found
+            </Typography>
+            <Typography align="center" color="textSecondary">
+              Create a new analysis to generate insights across multiple resources.
+            </Typography>
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3 }}>
+              <Button
+                variant="contained"
+                color="primary"
+                component={Link}
+                to={`/dashboard/integrations/create-analysis/${teamId}`}
+              >
+                Create Analysis
+              </Button>
+            </Box>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <TableContainer component={Paper}>
+            <Table sx={{ minWidth: 650 }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Title</TableCell>
+                  <TableCell>Created</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Resources</TableCell>
+                  <TableCell>Created By</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {reports.map((report) => {
+                  const statusInfo = getStatusStyles(report.status);
+                  return (
+                    <TableRow key={report.id} hover>
+                      <TableCell component="th" scope="row">
+                        <Typography variant="body1" fontWeight="medium">
+                          {report.title}
+                        </Typography>
+                        {report.description && (
+                          <Typography variant="body2" color="textSecondary" noWrap sx={{ maxWidth: 300 }}>
+                            {report.description}
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>{formatDate(report.created_at)}</TableCell>
+                      <TableCell>
+                        <Chip 
+                          label={statusInfo.label} 
+                          color={statusInfo.color as any} 
+                          size="small" 
+                          variant="filled" 
+                        />
+                      </TableCell>
+                      <TableCell>{report.resource_count}</TableCell>
+                      <TableCell>
+                        {report.created_by?.name || report.created_by?.email || 'Unknown user'}
+                      </TableCell>
+                      <TableCell align="right">
+                        <Tooltip title="View Report">
+                          <IconButton 
+                            component={Link} 
+                            to={`/dashboard/integrations/team-analysis/${report.id}`}
+                            color="primary"
+                          >
+                            <ViewIcon />
+                          </IconButton>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <TablePagination
+            rowsPerPageOptions={[5, 10, 25]}
+            component="div"
+            count={totalCount}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onPageChange={handleChangePage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+          />
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default CrossResourceReportsPage;

--- a/frontend/src/pages/reports/index.ts
+++ b/frontend/src/pages/reports/index.ts
@@ -1,0 +1,5 @@
+import CrossResourceReportsPage from './CrossResourceReportsPage';
+
+export {
+  CrossResourceReportsPage
+};


### PR DESCRIPTION
## Summary
- Add getCrossResourceReports method to integrationService
- Create CrossResourceReportsPage component for team analyses history 
- Update App.tsx with new route for reports history
- Enhance Analytics page to list real reports from API
- Add new reports navigation item to sidebar

## Test plan
- ✅ TypeScript compilation passes
- ✅ ESLint checks pass
- Unit tests for CrossResourceReportsPage component
- Manually test report listing and pagination
- Check API error handling and empty state
- Verify links to individual reports work correctly

Fixes #244

🤖 Generated with [Claude Code](https://claude.ai/code)