### PR TITLE
Remove SECRET_KEY and OPENAI_API_KEY, make OPENROUTER_API_KEY required

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -13,8 +13,8 @@ SUPABASE_KEY=your_supabase_service_role_key
 SUPABASE_JWT_SECRET=your_supabase_jwt_secret
 SUPABASE_ANON_KEY=your_supabase_anon_key
 
-# OpenAI API key (replace with your own value)
-OPENAI_API_KEY=your_openai_api_key
+# OpenRouter API key (replace with your own value)
+OPENROUTER_API_KEY=your_openrouter_api_key
 
 # Optional: Integration settings
 # Note: Slack credentials are now entered directly in the UI and no longer need to be set as environment variables

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -47,11 +47,10 @@ jobs:
         mkdir -p /tmp
         echo "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/test_db" > .env.test
         echo "DATABASE_TEST_URL=postgresql://postgres:postgres@localhost:5432/test_db" >> .env.test
-        echo "SECRET_KEY=test-secret-key-for-ci" >> .env.test
         echo "SUPABASE_URL=https://example.supabase.co" >> .env.test
         echo "SUPABASE_KEY=test-supabase-key" >> .env.test
         echo "SUPABASE_JWT_SECRET=test-jwt-secret" >> .env.test
-        echo "OPENAI_API_KEY=sk-test-key" >> .env.test
+        echo "OPENROUTER_API_KEY=sk-test-key" >> .env.test
 
     - name: Check environment variables
       env:
@@ -59,11 +58,10 @@ jobs:
         TESTING: "True"
         DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/test_db"
         DATABASE_TEST_URL: "postgresql://postgres:postgres@localhost:5432/test_db"
-        SECRET_KEY: "test-secret-key-for-ci"
         SUPABASE_URL: "https://example.supabase.co"
         SUPABASE_KEY: "test-supabase-key"
         SUPABASE_JWT_SECRET: "test-jwt-secret"
-        OPENAI_API_KEY: "sk-test-key"
+        OPENROUTER_API_KEY: "sk-test-key"
       run: python scripts/check_env.py --env-file .env.test --no-exit
 
     - name: Run tests with pytest
@@ -71,11 +69,10 @@ jobs:
         TESTING: "True"
         DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/test_db"
         DATABASE_TEST_URL: "postgresql://postgres:postgres@localhost:5432/test_db"
-        SECRET_KEY: "test-secret-key-for-ci-environment"
         SUPABASE_URL: "https://example.supabase.co"
         SUPABASE_KEY: "test-supabase-key"
         SUPABASE_JWT_SECRET: "test-jwt-secret"
-        OPENAI_API_KEY: "sk-test-key"
+        OPENROUTER_API_KEY: "sk-test-key"
       run: pytest --cov=app --cov-report=xml
 
     - name: Upload coverage to Codecov

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -56,8 +56,7 @@ If you prefer to set up the resources manually instead of using CDK, follow thes
    - `SUPABASE_URL`: Your Supabase project URL
    - `SUPABASE_KEY`: Your Supabase service role key
    - `SUPABASE_JWT_SECRET`: Your Supabase JWT signing secret
-   - `OPENAI_API_KEY`: Your OpenAI API key
-   - Note: `SECRET_KEY` is defined in the config but not currently used by the application
+   - `OPENROUTER_API_KEY`: Your OpenRouter API key
 
 4. **Set Up Database:**
    - Create an RDS PostgreSQL instance

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ nano .env.docker  # or use any text editor
 Required Docker environment variables:
 - `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`: Database connection settings
 - `SUPABASE_URL`, `SUPABASE_KEY`, `SUPABASE_JWT_SECRET`, `SUPABASE_ANON_KEY`: Supabase authentication settings
-- `OPENAI_API_KEY`: For AI-powered analysis
+- `OPENROUTER_API_KEY`: For AI-powered analysis
 - Integration variables (as needed):
   - Note: Slack credentials are now entered directly in the UI and not required as environment variables
   - `NGROK_URL`: Your ngrok HTTPS URL for development with Slack OAuth
@@ -465,7 +465,6 @@ Required backend environment variables:
 - `SUPABASE_URL`, `SUPABASE_KEY`, `SUPABASE_JWT_SECRET`: Supabase authentication settings
 - `OPENROUTER_API_KEY`: API key for LLM access via OpenRouter
 - `OPENROUTER_DEFAULT_MODEL`: Default LLM model to use (e.g., `anthropic/claude-3-opus:20240229`)
-- Note: `SECRET_KEY` is defined in the config but not currently used by the application
 - Note: Slack credentials are now entered directly in the UI and not required as environment variables
 
 ### Frontend Environment Variables

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,4 @@
 # API Settings
-# Note: SECRET_KEY is defined in the config but not currently used by the application
 DEBUG=True
 
 # Database Settings
@@ -11,7 +10,7 @@ SUPABASE_KEY=your_supabase_service_role_key
 SUPABASE_JWT_SECRET=your_supabase_jwt_secret
 
 # Third-Party API Keys
-OPENAI_API_KEY=your_openai_api_key
+OPENROUTER_API_KEY=your_openrouter_api_key
 # Note: Slack credentials are now entered directly in the UI and no longer need to be set as environment variables
 GITHUB_CLIENT_ID=your_github_client_id
 GITHUB_CLIENT_SECRET=your_github_client_secret

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -67,9 +67,6 @@ class Settings(BaseSettings):
         # Convert back to list for return
         return list(unique_hosts)
 
-    # Secret Keys
-    SECRET_KEY: str
-
     # Database Settings
     DATABASE_URL: PostgresDsn
     DATABASE_TEST_URL: Optional[PostgresDsn] = None
@@ -80,8 +77,7 @@ class Settings(BaseSettings):
     SUPABASE_JWT_SECRET: str
 
     # Third-Party API Keys
-    OPENAI_API_KEY: SecretStr
-    OPENROUTER_API_KEY: Optional[SecretStr] = None
+    OPENROUTER_API_KEY: SecretStr
     OPENROUTER_DEFAULT_MODEL: str = "anthropic/claude-3-sonnet:20240229"
     OPENROUTER_MAX_TOKENS: int = 4000
     OPENROUTER_TEMPERATURE: float = 0.7


### PR DESCRIPTION
# Remove SECRET_KEY and OPENAI_API_KEY, make OPENROUTER_API_KEY required

## Issue
When running the backend locally with `uvicorn app.main:app --reload`, validation errors occur for missing SECRET_KEY and OPENAI_API_KEY environment variables, even though these variables are not functionally used in the application.

## Changes Made
1. Removed SECRET_KEY and OPENAI_API_KEY from the Settings class in config.py
2. Made OPENROUTER_API_KEY a required field instead of optional
3. Updated documentation and example files to reflect these changes:
   - .env.docker.example
   - backend/.env.example
   - README.md
   - DEPLOYMENT.md
4. Updated CI workflow to use OPENROUTER_API_KEY instead of SECRET_KEY and OPENAI_API_KEY

## Benefits
- Simplifies local development setup by removing unused environment variables
- Makes it clear that OPENROUTER_API_KEY is required for the application to function properly
- Aligns configuration with actual application usage