### PR TITLE
Fix TypeScript errors in frontend components

### DIFF
--- a/frontend/src/__tests__/components/integration/IntegrationList.test.tsx
+++ b/frontend/src/__tests__/components/integration/IntegrationList.test.tsx
@@ -90,6 +90,7 @@ const mockIntegrationContext = {
   analyzeChannel: vi.fn(),
   clearErrors: vi.fn(),
   clearChannelSelectionError: vi.fn(),
+  getWorkspaceIdForAnalysis: vi.fn().mockResolvedValue(null),
 }
 
 describe('IntegrationList', () => {

--- a/frontend/src/__tests__/components/integration/TeamChannelSelector.test.tsx
+++ b/frontend/src/__tests__/components/integration/TeamChannelSelector.test.tsx
@@ -158,6 +158,9 @@ const mockIntegrationContext = {
   // Analysis operations
   analyzeChannel: vi.fn(),
 
+  // Workspace operations
+  getWorkspaceIdForAnalysis: vi.fn().mockResolvedValue(null),
+
   // Error handling
   clearErrors: vi.fn(),
   clearChannelSelectionError: vi.fn(),
@@ -377,6 +380,7 @@ describe('TeamChannelSelector', () => {
           last_synced_at: '2023-01-01T00:00:00Z',
         },
       ],
+      getWorkspaceIdForAnalysis: vi.fn().mockResolvedValue(null),
     }
 
     // Re-render with updated mock context
@@ -417,6 +421,7 @@ describe('TeamChannelSelector', () => {
           last_synced_at: '2023-01-01T00:00:00Z',
         },
       ],
+      getWorkspaceIdForAnalysis: vi.fn().mockResolvedValue(null),
     }
 
     // Re-render with updated mock
@@ -498,6 +503,7 @@ describe('TeamChannelSelector', () => {
     const loadingMock = {
       ...mockIntegrationContext,
       loadingChannelSelection: true,
+      getWorkspaceIdForAnalysis: vi.fn().mockResolvedValue(null),
     }
 
     await act(async () => {

--- a/frontend/src/__tests__/components/slack/MessageText.test.tsx
+++ b/frontend/src/__tests__/components/slack/MessageText.test.tsx
@@ -37,7 +37,7 @@ describe('MessageText', () => {
   it('renders plain text correctly', () => {
     render(
       <ChakraProvider>
-        <MessageText text="Hello, world!" workspaceId={mockWorkspaceId} />
+        <MessageText text="Hello, world!" workspaceUuid={mockWorkspaceId} />
       </ChakraProvider>
     )
 
@@ -47,7 +47,7 @@ describe('MessageText', () => {
   it('handles newlines correctly', () => {
     render(
       <ChakraProvider>
-        <MessageText text="Line 1\nLine 2" workspaceId={mockWorkspaceId} />
+        <MessageText text="Line 1\nLine 2" workspaceUuid={mockWorkspaceId} />
       </ChakraProvider>
     )
 
@@ -64,7 +64,7 @@ describe('MessageText', () => {
       <ChakraProvider>
         <MessageText
           text="Hello <@U12345>!"
-          workspaceId={mockWorkspaceId}
+          workspaceUuid={mockWorkspaceId}
           resolveMentions={true}
         />
       </ChakraProvider>
@@ -74,7 +74,7 @@ describe('MessageText', () => {
     expect(SlackUserDisplayMock).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: 'U12345',
-        workspaceId: mockWorkspaceId,
+        workspaceUuid: mockWorkspaceId,
         displayFormat: 'username',
         fetchFromSlack: true,
         asComponent: 'span',
@@ -95,7 +95,7 @@ describe('MessageText', () => {
       <ChakraProvider>
         <MessageText
           text="Hello <@U12345>!"
-          workspaceId={mockWorkspaceId}
+          workspaceUuid={mockWorkspaceId}
           resolveMentions={false}
         />
       </ChakraProvider>
@@ -113,7 +113,7 @@ describe('MessageText', () => {
       <ChakraProvider>
         <MessageText
           text="Hello <@U12345> and <@U67890>!"
-          workspaceId={mockWorkspaceId}
+          workspaceUuid={mockWorkspaceId}
           resolveMentions={false}
         />
       </ChakraProvider>
@@ -127,7 +127,7 @@ describe('MessageText', () => {
       <ChakraProvider>
         <MessageText
           text="Hello <@U12345>\nHow are you?"
-          workspaceId={mockWorkspaceId}
+          workspaceUuid={mockWorkspaceId}
           resolveMentions={false}
         />
       </ChakraProvider>
@@ -141,7 +141,7 @@ describe('MessageText', () => {
   it('renders null for empty text', () => {
     // Render without ChakraProvider to avoid the Chakra env span
     const { container } = render(
-      <MessageText text="" workspaceId={mockWorkspaceId} />
+      <MessageText text="" workspaceUuid={mockWorkspaceId} />
     )
 
     // Check that our component didn't render anything
@@ -154,7 +154,7 @@ describe('MessageText', () => {
       <ChakraProvider>
         <MessageText
           text="Hello <@ERROR_USER>!"
-          workspaceId={mockWorkspaceId}
+          workspaceUuid={mockWorkspaceId}
           resolveMentions={false}
         />
       </ChakraProvider>

--- a/frontend/src/__tests__/lib/slackApiClient.test.ts
+++ b/frontend/src/__tests__/lib/slackApiClient.test.ts
@@ -21,11 +21,10 @@ console.error = vi.fn()
 describe('SlackApiClient', () => {
   const mockWorkspaceId = 'workspace-123'
   const mockUserIds = ['U12345', 'U67890', 'U24680']
-  
+
   beforeEach(() => {
     mockFetch.mockClear()
     vi.clearAllMocks()
-    
     ;(supabase.auth.getSession as ReturnType<typeof vi.fn>).mockResolvedValue({
       data: {
         session: {
@@ -34,47 +33,50 @@ describe('SlackApiClient', () => {
       },
     })
   })
-  
+
   afterEach(() => {
     vi.restoreAllMocks()
   })
-  
+
   afterAll(() => {
     console.log = originalConsoleLog
     console.error = originalConsoleError
   })
-  
+
   const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
-  
+
   describe('getUsersByIds', () => {
     it('should correctly handle multiple user IDs using URLSearchParams', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({
-          users: [
-            { id: '1', slack_id: 'U12345', name: 'user1' },
-            { id: '2', slack_id: 'U67890', name: 'user2' },
-            { id: '3', slack_id: 'U24680', name: 'user3' },
-          ],
-        }),
+        json: () =>
+          Promise.resolve({
+            users: [
+              { id: '1', slack_id: 'U12345', name: 'user1' },
+              { id: '2', slack_id: 'U67890', name: 'user2' },
+              { id: '3', slack_id: 'U24680', name: 'user3' },
+            ],
+          }),
       })
-      
+
       const resultPromise = slackApiClient.getUsersByIds(
         mockWorkspaceId,
         mockUserIds,
         true
       )
-      
+
       await flushPromises()
-      
+
       expect(mockFetch).toHaveBeenCalledTimes(1)
-      
+
       const fetchUrl = mockFetch.mock.calls[0][0]
-      
-      expect(fetchUrl).toContain(`user_ids%5B%5D=${mockUserIds[mockUserIds.length - 1]}`)
-      
+
+      expect(fetchUrl).toContain(
+        `user_ids%5B%5D=${mockUserIds[mockUserIds.length - 1]}`
+      )
+
       expect(fetchUrl).toContain('fetch_from_slack=true')
-      
+
       const result = await resultPromise
       expect(result).toEqual({
         users: [
@@ -84,42 +86,42 @@ describe('SlackApiClient', () => {
         ],
       })
     })
-    
+
     it('should handle empty user IDs array', async () => {
       const result = await slackApiClient.getUsersByIds(mockWorkspaceId, [])
-      
+
       expect(mockFetch).not.toHaveBeenCalled()
       expect(result).toEqual({ users: [] })
     })
-    
+
     it('should handle fetch errors gracefully', async () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
-      
+
       const result = await slackApiClient.getUsersByIds(
         mockWorkspaceId,
         mockUserIds
       )
-      
+
       expect(result).toEqual({
         status: 'NETWORK_ERROR',
         message: 'Network Error: Network error',
       })
     })
-    
+
     it('should handle API errors', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 403,
         statusText: 'Forbidden',
       })
-      
+
       const resultPromise = slackApiClient.getUsersByIds(
         mockWorkspaceId,
         mockUserIds
       )
-      
+
       await flushPromises()
-      
+
       const result = await resultPromise
       expect(result).toEqual({
         status: 403,

--- a/frontend/src/__tests__/pages/integration/TeamChannelSelectorPage.test.tsx
+++ b/frontend/src/__tests__/pages/integration/TeamChannelSelectorPage.test.tsx
@@ -117,6 +117,7 @@ const mockIntegrationContext = {
   analyzeChannel: vi.fn(),
   clearErrors: vi.fn(),
   clearChannelSelectionError: vi.fn(),
+  getWorkspaceIdForAnalysis: vi.fn().mockResolvedValue(null),
 }
 
 describe('TeamChannelSelectorPage', () => {

--- a/frontend/src/components/examples/WorkspaceIdFromAnalysisExample.tsx
+++ b/frontend/src/components/examples/WorkspaceIdFromAnalysisExample.tsx
@@ -1,11 +1,20 @@
 import React, { useContext, useEffect, useState } from 'react'
-import { Box, Button, Text, VStack, Code, Spinner, Alert, AlertIcon } from '@chakra-ui/react'
+import {
+  Box,
+  Button,
+  Text,
+  VStack,
+  Code,
+  Spinner,
+  Alert,
+  AlertIcon,
+} from '@chakra-ui/react'
 import IntegrationContext from '../../context/IntegrationContext'
 import { WorkspaceIdResponse } from '../../lib/integrationService'
 
 /**
  * Example component demonstrating how to retrieve workspace ID from a resource analysis ID
- * 
+ *
  * This component shows:
  * 1. How to access the IntegrationContext
  * 2. How to call the getWorkspaceIdForAnalysis method
@@ -16,12 +25,13 @@ interface WorkspaceIdFromAnalysisExampleProps {
   analysisId: string
 }
 
-const WorkspaceIdFromAnalysisExample: React.FC<WorkspaceIdFromAnalysisExampleProps> = ({
-  analysisId
-}) => {
+const WorkspaceIdFromAnalysisExample: React.FC<
+  WorkspaceIdFromAnalysisExampleProps
+> = ({ analysisId }) => {
   const integrationContext = useContext(IntegrationContext)
-  
-  const [workspaceData, setWorkspaceData] = useState<WorkspaceIdResponse | null>(null)
+
+  const [workspaceData, setWorkspaceData] =
+    useState<WorkspaceIdResponse | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -36,9 +46,10 @@ const WorkspaceIdFromAnalysisExample: React.FC<WorkspaceIdFromAnalysisExamplePro
 
     try {
       console.log(`Fetching workspace ID for analysis: ${analysisId}`)
-      
-      const result = await integrationContext.getWorkspaceIdForAnalysis(analysisId)
-      
+
+      const result =
+        await integrationContext.getWorkspaceIdForAnalysis(analysisId)
+
       if (result) {
         console.log('Workspace data retrieved:', result)
         setWorkspaceData(result)
@@ -60,10 +71,18 @@ const WorkspaceIdFromAnalysisExample: React.FC<WorkspaceIdFromAnalysisExamplePro
   }, [analysisId])
 
   return (
-    <Box p={4} borderWidth="1px" borderRadius="lg" width="100%" maxWidth="600px">
+    <Box
+      p={4}
+      borderWidth="1px"
+      borderRadius="lg"
+      width="100%"
+      maxWidth="600px"
+    >
       <VStack spacing={4} align="stretch">
-        <Text fontSize="xl" fontWeight="bold">Workspace ID from Analysis Example</Text>
-        
+        <Text fontSize="xl" fontWeight="bold">
+          Workspace ID from Analysis Example
+        </Text>
+
         <Box>
           <Text fontWeight="medium">Analysis ID:</Text>
           <Code p={2} borderRadius="md" width="100%">
@@ -72,9 +91,9 @@ const WorkspaceIdFromAnalysisExample: React.FC<WorkspaceIdFromAnalysisExamplePro
         </Box>
 
         {/* Manual fetch button */}
-        <Button 
-          colorScheme="blue" 
-          onClick={fetchWorkspaceId} 
+        <Button
+          colorScheme="blue"
+          onClick={fetchWorkspaceId}
           isLoading={isLoading}
           isDisabled={!analysisId}
         >
@@ -100,7 +119,9 @@ const WorkspaceIdFromAnalysisExample: React.FC<WorkspaceIdFromAnalysisExamplePro
         {/* Results display */}
         {workspaceData && (
           <Box borderWidth="1px" borderRadius="md" p={3} bg="gray.50">
-            <Text fontWeight="bold" mb={2}>Workspace Information:</Text>
+            <Text fontWeight="bold" mb={2}>
+              Workspace Information:
+            </Text>
             <VStack align="stretch" spacing={2}>
               <Box>
                 <Text fontWeight="medium">Workspace ID:</Text>

--- a/frontend/src/components/slack/MessageList.tsx
+++ b/frontend/src/components/slack/MessageList.tsx
@@ -75,7 +75,8 @@ interface PaginationInfo {
 }
 
 interface MessageListProps {
-  workspaceId: string
+  workspaceId?: string
+  workspaceUuid?: string
   channelId: string
   channelName?: string
 }
@@ -85,9 +86,11 @@ interface MessageListProps {
  */
 const MessageList: React.FC<MessageListProps> = ({
   workspaceId,
+  workspaceUuid,
   channelId,
   channelName,
 }) => {
+  const effectiveWorkspaceId = workspaceUuid || workspaceId || ''
   const [messages, setMessages] = useState<SlackMessage[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [isSyncing, setIsSyncing] = useState(false)
@@ -109,7 +112,7 @@ const MessageList: React.FC<MessageListProps> = ({
   useEffect(() => {
     fetchMessages()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaceId, channelId, cursor])
+  }, [effectiveWorkspaceId, channelId, cursor])
 
   /**
    * Fetch channel messages from the API.
@@ -119,7 +122,7 @@ const MessageList: React.FC<MessageListProps> = ({
       setIsLoading(true)
 
       // Construct the URL with query parameters
-      let url = `${env.apiUrl}/slack/workspaces/${workspaceId}/channels/${channelId}/messages?include_replies=${includeReplies}`
+      let url = `${env.apiUrl}/slack/workspaces/${effectiveWorkspaceId}/channels/${channelId}/messages?include_replies=${includeReplies}`
 
       if (startDate) {
         // Create a date at the beginning of the selected day (00:00:00)
@@ -214,7 +217,7 @@ const MessageList: React.FC<MessageListProps> = ({
         thread_days: 30, // Sync last 30 days of threads by default
       }
 
-      const syncUrl = `${env.apiUrl}/slack/workspaces/${workspaceId}/channels/${channelId}/sync`
+      const syncUrl = `${env.apiUrl}/slack/workspaces/${effectiveWorkspaceId}/channels/${channelId}/sync`
       // Start the sync process
 
       const response = await fetch(syncUrl, {
@@ -318,7 +321,7 @@ const MessageList: React.FC<MessageListProps> = ({
   )
 
   return (
-    <SlackUserCacheProvider workspaceId={workspaceId}>
+    <SlackUserCacheProvider workspaceUuid={effectiveWorkspaceId}>
       <Box p={6} width="100%" maxWidth="1000px" mx="auto">
         <HStack justifyContent="space-between" mb={6}>
           <Heading size="lg">
@@ -444,7 +447,7 @@ const MessageList: React.FC<MessageListProps> = ({
                           <Box>
                             <SlackUserDisplay
                               userId={message.user_id || ''}
-                              workspaceId={workspaceId}
+                              workspaceUuid={effectiveWorkspaceId}
                               showAvatar={true}
                               displayFormat="real_name"
                               fetchFromSlack={true}
@@ -466,7 +469,7 @@ const MessageList: React.FC<MessageListProps> = ({
                         <Box pl={10} pr={2}>
                           <MessageText
                             text={message.text}
-                            workspaceId={workspaceId}
+                            workspaceUuid={workspaceId}
                             resolveMentions={true}
                             fallbackToSimpleFormat={true}
                           />
@@ -535,7 +538,7 @@ const MessageList: React.FC<MessageListProps> = ({
         <ThreadView
           isOpen={isThreadViewOpen}
           onClose={() => setIsThreadViewOpen(false)}
-          workspaceId={workspaceId}
+          workspaceId={effectiveWorkspaceId}
           channelId={channelId}
           threadTs={selectedThreadTs}
           parentMessage={selectedThreadParent}

--- a/frontend/src/components/slack/MessageText.tsx
+++ b/frontend/src/components/slack/MessageText.tsx
@@ -153,11 +153,11 @@ const MessageText: React.FC<MessageTextProps> = ({
           {/* Don't add @ prefix if it was already in @userId format */}
           {!wasSimpleFormat && '@'}
           <SlackUserCacheProvider
-            workspaceId={workspaceUuid ||''} // Use workspaceUuid if provided, otherwise fallback to workspaceId
+            workspaceUuid={workspaceUuid || ''} // Use workspaceUuid if provided, otherwise fallback to workspaceId
           >
             <SlackUserDisplay
               userId={userId}
-              workspaceId={workspaceUuid}
+              workspaceUuid={workspaceUuid}
               displayFormat="username"
               fetchFromSlack={true} // Always try to fetch from Slack if user not in DB
               asComponent="span"

--- a/frontend/src/components/slack/SlackUserContext.tsx
+++ b/frontend/src/components/slack/SlackUserContext.tsx
@@ -8,11 +8,14 @@ import {
 // Provider component for the UserCache
 export const SlackUserCacheProvider: React.FC<{
   children: React.ReactNode
-  workspaceId: string
-}> = ({ children, workspaceId }) => {
+  workspaceId?: string
+  workspaceUuid?: string
+}> = ({ children, workspaceId, workspaceUuid }) => {
+  // Use workspaceUuid if provided, otherwise fall back to workspaceId
+  const effectiveWorkspaceId = workspaceUuid || workspaceId || ''
   console.log(
     'SlackUserCacheProvider initialized with workspace ID:',
-    workspaceId
+    effectiveWorkspaceId
   )
   const [users, setUsers] = useState<Map<string, SlackUser>>(new Map())
   const [loading, setLoading] = useState<Set<string>>(new Set())
@@ -24,7 +27,7 @@ export const SlackUserCacheProvider: React.FC<{
     wsId?: string
   ): Promise<SlackUser | undefined> => {
     // Use provided workspace ID or fall back to the provider's workspaceId
-    const targetWorkspaceId = wsId || workspaceId
+    const targetWorkspaceId = wsId || effectiveWorkspaceId
 
     console.log(
       `fetchUser called for userId: ${userId}, wsId: ${wsId}, using targetWorkspaceId: ${targetWorkspaceId}`

--- a/frontend/src/components/slack/SlackUserDisplayDemo.tsx
+++ b/frontend/src/components/slack/SlackUserDisplayDemo.tsx
@@ -37,7 +37,7 @@ const SlackUserDisplayDemo: React.FC = () => {
         workspace IDs with real ones to see actual data.
       </Text>
 
-      <SlackUserCacheProvider workspaceId={demoWorkspaceId}>
+      <SlackUserCacheProvider workspaceUuid={demoWorkspaceId}>
         <Card mb={8}>
           <CardHeader>
             <Heading size="md">Basic Usage</Heading>

--- a/frontend/src/components/slack/ThreadView.tsx
+++ b/frontend/src/components/slack/ThreadView.tsx
@@ -177,7 +177,7 @@ const ThreadView: React.FC<ThreadViewProps> = ({
           <Box>
             <SlackUserDisplay
               userId={parentMessage.user_id || ''}
-              workspaceId={workspaceId}
+              workspaceUuid={workspaceId}
               showAvatar={true}
               displayFormat="real_name"
               fetchFromSlack={true}
@@ -199,7 +199,7 @@ const ThreadView: React.FC<ThreadViewProps> = ({
         <Box pl={10} pr={2}>
           <MessageText
             text={parentMessage.text}
-            workspaceId={workspaceId}
+            workspaceUuid={workspaceId}
             resolveMentions={true}
             fallbackToSimpleFormat={true}
           />
@@ -237,7 +237,7 @@ const ThreadView: React.FC<ThreadViewProps> = ({
           <Box>
             <SlackUserDisplay
               userId={message.user_id || ''}
-              workspaceId={workspaceId}
+              workspaceUuid={workspaceId}
               showAvatar={true}
               displayFormat="real_name"
               fetchFromSlack={true}
@@ -259,7 +259,7 @@ const ThreadView: React.FC<ThreadViewProps> = ({
         <Box pl={10} pr={2}>
           <MessageText
             text={message.text}
-            workspaceId={workspaceId}
+            workspaceUuid={workspaceId}
             resolveMentions={true}
             fallbackToSimpleFormat={true}
           />
@@ -279,7 +279,7 @@ const ThreadView: React.FC<ThreadViewProps> = ({
   }
 
   return (
-    <SlackUserCacheProvider workspaceId={workspaceId}>
+    <SlackUserCacheProvider workspaceUuid={workspaceId}>
       <Modal
         isOpen={isOpen}
         onClose={onClose}

--- a/frontend/src/context/IntegrationContext.tsx
+++ b/frontend/src/context/IntegrationContext.tsx
@@ -74,7 +74,7 @@ interface IntegrationContextType extends IntegrationState {
     integrationId: string,
     resourceTypes?: string[]
   ) => Promise<boolean>
-  
+
   // Workspace operations
   getWorkspaceIdForAnalysis: (
     analysisId: string
@@ -144,7 +144,7 @@ const IntegrationContext = createContext<IntegrationContextType>({
   // Resource operations
   fetchResources: async () => {},
   syncResources: async () => false,
-  
+
   // Workspace operations
   getWorkspaceIdForAnalysis: async () => null,
 
@@ -1162,7 +1162,7 @@ export const IntegrationProvider: React.FC<{ children: React.ReactNode }> = ({
     },
     [session]
   )
-  
+
   /**
    * Get workspace ID for a resource analysis
    * @param analysisId Resource analysis UUID
@@ -1175,7 +1175,8 @@ export const IntegrationProvider: React.FC<{ children: React.ReactNode }> = ({
       setState((prev) => ({ ...prev, loading: true, error: null }))
 
       try {
-        const result = await integrationService.getWorkspaceIdForAnalysis(analysisId)
+        const result =
+          await integrationService.getWorkspaceIdForAnalysis(analysisId)
 
         if (integrationService.isApiError(result)) {
           setState((prev) => ({

--- a/frontend/src/lib/slackApiClient.ts
+++ b/frontend/src/lib/slackApiClient.ts
@@ -263,21 +263,24 @@ class SlackApiClient extends ApiClient {
       const path = `/workspaces/${workspaceId}/users`
 
       // Create URLSearchParams object to properly handle multiple parameters with the same name
-      const searchParams = new URLSearchParams();
-      
+      const searchParams = new URLSearchParams()
+
       // Add fetch_from_slack parameter
-      searchParams.append('fetch_from_slack', fetchFromSlack.toString());
-      
+      searchParams.append('fetch_from_slack', fetchFromSlack.toString())
+
       // Add user_ids[] parameter for each user ID
       userIds.forEach((id) => {
-        searchParams.append('user_ids[]', id);
-      });
-      
-      const params = Object.fromEntries(searchParams.entries());
+        searchParams.append('user_ids[]', id)
+      })
+
+      const params = Object.fromEntries(searchParams.entries())
 
       console.log('[SlackApiClient] getUsersByIds - Using path:', path)
       console.log('[SlackApiClient] getUsersByIds - Using params:', params)
-      console.log('[SlackApiClient] getUsersByIds - URLSearchParams:', searchParams.toString())
+      console.log(
+        '[SlackApiClient] getUsersByIds - URLSearchParams:',
+        searchParams.toString()
+      )
 
       return this.get<{ users: BaseSlackUser[] }>(path, params)
     } catch (error) {
@@ -356,16 +359,20 @@ class SlackApiClient extends ApiClient {
     integrationId: string
   ): Promise<string | ApiError> {
     if (!integrationId) {
-      console.warn('[SlackApiClient] getWorkspaceIdFromIntegration - No integrationId provided')
+      console.warn(
+        '[SlackApiClient] getWorkspaceIdFromIntegration - No integrationId provided'
+      )
       return ''
     }
 
     try {
       // Use the integration endpoint to get the integration details
       const apiUrl = `${env.apiUrl}/integrations/${integrationId}`
-      
-      console.log(`[SlackApiClient] getWorkspaceIdFromIntegration - Fetching from ${apiUrl}`)
-      
+
+      console.log(
+        `[SlackApiClient] getWorkspaceIdFromIntegration - Fetching from ${apiUrl}`
+      )
+
       const response = await fetch(apiUrl, {
         method: 'GET',
         headers: {
@@ -383,18 +390,27 @@ class SlackApiClient extends ApiClient {
       }
 
       const integration = await response.json()
-      
-      if (integration && 
-          integration.metadata && 
-          integration.metadata.workspace_id) {
-        console.log(`[SlackApiClient] getWorkspaceIdFromIntegration - Found workspace_id: ${integration.metadata.workspace_id}`)
+
+      if (
+        integration &&
+        integration.metadata &&
+        integration.metadata.workspace_id
+      ) {
+        console.log(
+          `[SlackApiClient] getWorkspaceIdFromIntegration - Found workspace_id: ${integration.metadata.workspace_id}`
+        )
         return integration.metadata.workspace_id
       }
-      
-      console.warn('[SlackApiClient] getWorkspaceIdFromIntegration - No workspace_id found in integration metadata')
+
+      console.warn(
+        '[SlackApiClient] getWorkspaceIdFromIntegration - No workspace_id found in integration metadata'
+      )
       return ''
     } catch (error) {
-      console.error('[SlackApiClient] getWorkspaceIdFromIntegration - Error:', error)
+      console.error(
+        '[SlackApiClient] getWorkspaceIdFromIntegration - Error:',
+        error
+      )
       return {
         status: 'CLIENT_ERROR',
         message: `Error fetching workspace ID: ${error instanceof Error ? error.message : String(error)}`,

--- a/frontend/src/pages/integration/TeamAnalysisResultPage.tsx
+++ b/frontend/src/pages/integration/TeamAnalysisResultPage.tsx
@@ -110,7 +110,10 @@ const ChannelAnalysisList: FC<ChannelAnalysisListProps> = ({
   // Use react-router's useNavigate hook for navigation
   const navigate = useNavigate()
   // Function to format plain text with proper formatting and support for markdown-like syntax
-  const renderPlainText = (text: string | unknown, workspaceUuid: string | undefined) => {
+  const renderPlainText = (
+    text: string | unknown,
+    workspaceUuid: string | undefined
+  ) => {
     // Convert to string and handle undefined or empty text
     const textStr = typeof text === 'string' ? text : String(text || '')
     if (!textStr || textStr.trim().length === 0) {
@@ -608,7 +611,7 @@ const TeamAnalysisResultPage: React.FC = () => {
         model_used: String(firstAnalysis.model_used || 'N/A'),
         generated_at: String(
           crossResourceReport.created_at || new Date().toISOString()
-        )
+        ),
       }
 
       console.log('Created adapted analysis for team report:', adaptedAnalysis)
@@ -647,7 +650,7 @@ const TeamAnalysisResultPage: React.FC = () => {
         model_used: 'N/A',
         generated_at: String(
           crossResourceReport.created_at || new Date().toISOString()
-        )
+        ),
       }
 
       setAnalysis(emptyAnalysis)
@@ -1896,8 +1899,8 @@ Generated using Toban Contribution Viewer with ${analysis.model_used}
                           ? fixedChannelSummary
                           : typeof analysis?.channel_summary === 'string'
                             ? analysis.channel_summary
-                            : 'No summary available'
-                        , ''
+                            : 'No summary available',
+                      ''
                     )}
                   </Box>
                 </CardBody>

--- a/frontend/src/pages/integration/TeamChannelAnalysisPage.tsx
+++ b/frontend/src/pages/integration/TeamChannelAnalysisPage.tsx
@@ -451,7 +451,7 @@ const TeamChannelAnalysisPage: React.FC = () => {
         {paragraph.trim() ? (
           <MessageText
             text={paragraph}
-            workspaceId={channel?.external_id || ''}
+            workspaceUuid={channel?.external_id || ''}
             resolveMentions={true}
             fallbackToSimpleFormat={true}
           />

--- a/frontend/src/pages/slack/MessagesPage.tsx
+++ b/frontend/src/pages/slack/MessagesPage.tsx
@@ -179,7 +179,7 @@ const MessagesPage: React.FC = () => {
       {/* Message list */}
       {workspaceId && channelId && (
         <MessageList
-          workspaceId={workspaceId}
+          workspaceUuid={workspaceId}
           channelId={channelId}
           channelName={channel?.name}
         />


### PR DESCRIPTION
This PR addresses TypeScript errors in the frontend code that were causing CI checks to fail.

## Changes

### 1. Added missing `getWorkspaceIdForAnalysis` property to test contexts
- Added the property to mock IntegrationContext in test files
- Implemented with `vi.fn().mockResolvedValue(null)` to match expected behavior

### 2. Fixed property naming inconsistency between `workspaceId` and `workspaceUuid`
- Updated components to consistently use `workspaceUuid` where required
- Modified SlackUserDisplay and related components to handle both property names
- Updated test expectations to match the new property names

### 3. Updated MessageList component to handle both property types
- Added support for both `workspaceId` and `workspaceUuid` with fallback logic
- Ensured backward compatibility with existing code

## Testing
- Verified all changes with `./run-ci-checks.sh --ci-compatible --all`
- All TypeScript errors are now resolved
- All tests are passing

## Link to Devin run
https://app.devin.ai/sessions/08f93c9a7f4a40b48207993699000ec4

Requested by: Hal Seki (hal@code4japan.org)
