### PR TITLE
Devin/1746508711 slack api mock service

### DIFF
--- a/integration-tests/mocks/slack-api/data/conversations.json
+++ b/integration-tests/mocks/slack-api/data/conversations.json
@@ -5,22 +5,61 @@
       "id": "C01234567",
       "name": "general",
       "is_channel": true,
+      "is_group": false,
+      "is_im": false,
+      "is_mpim": false,
       "is_private": false,
-      "is_archived": false
+      "created": 1614267200,
+      "is_archived": false,
+      "is_general": true,
+      "unlinked": 0,
+      "name_normalized": "general",
+      "is_shared": false,
+      "is_org_shared": false,
+      "is_pending_ext_shared": false,
+      "pending_shared": [],
+      "context_team_id": "T12345"
     },
     {
       "id": "C01234568",
       "name": "random",
       "is_channel": true,
+      "is_group": false,
+      "is_im": false,
+      "is_mpim": false,
       "is_private": false,
-      "is_archived": false
+      "created": 1614267300,
+      "is_archived": false,
+      "is_general": false,
+      "unlinked": 0,
+      "name_normalized": "random",
+      "is_shared": false,
+      "is_org_shared": false,
+      "is_pending_ext_shared": false,
+      "pending_shared": [],
+      "context_team_id": "T12345"
     },
     {
       "id": "C01234569",
       "name": "tech",
       "is_channel": true,
+      "is_group": false,
+      "is_im": false,
+      "is_mpim": false,
       "is_private": false,
-      "is_archived": false
+      "created": 1614267400,
+      "is_archived": false,
+      "is_general": false,
+      "unlinked": 0,
+      "name_normalized": "tech",
+      "is_shared": false,
+      "is_org_shared": false,
+      "is_pending_ext_shared": false,
+      "pending_shared": [],
+      "context_team_id": "T12345"
     }
-  ]
+  ],
+  "response_metadata": {
+    "next_cursor": ""
+  }
 }

--- a/integration-tests/mocks/slack-api/data/conversations.json
+++ b/integration-tests/mocks/slack-api/data/conversations.json
@@ -1,0 +1,26 @@
+{
+  "ok": true,
+  "channels": [
+    {
+      "id": "C01234567",
+      "name": "general",
+      "is_channel": true,
+      "is_private": false,
+      "is_archived": false
+    },
+    {
+      "id": "C01234568",
+      "name": "random",
+      "is_channel": true,
+      "is_private": false,
+      "is_archived": false
+    },
+    {
+      "id": "C01234569",
+      "name": "tech",
+      "is_channel": true,
+      "is_private": false,
+      "is_archived": false
+    }
+  ]
+}

--- a/integration-tests/mocks/slack-api/data/conversations_history_C01234567.json
+++ b/integration-tests/mocks/slack-api/data/conversations_history_C01234567.json
@@ -5,20 +5,80 @@
       "type": "message",
       "user": "U01234567",
       "text": "Hello everyone!",
-      "ts": "1614267200.000100"
+      "ts": "1614267200.000100",
+      "team": "T12345",
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "text1",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "Hello everyone!"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "client_msg_id": "01234567-abcd-4567-efgh-123456789abc"
     },
     {
       "type": "message",
       "user": "U01234568",
       "text": "Hi there!",
-      "ts": "1614267300.000200"
+      "ts": "1614267300.000200",
+      "team": "T12345",
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "text2",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "Hi there!"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "client_msg_id": "12345678-abcd-4567-efgh-123456789abc"
     },
     {
       "type": "message",
       "user": "U01234569",
       "text": "Good morning!",
-      "ts": "1614267400.000300"
+      "ts": "1614267400.000300",
+      "team": "T12345",
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "text3",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "Good morning!"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "client_msg_id": "23456789-abcd-4567-efgh-123456789abc"
     }
   ],
-  "has_more": false
+  "has_more": false,
+  "response_metadata": {
+    "next_cursor": ""
+  }
 }

--- a/integration-tests/mocks/slack-api/data/conversations_history_C01234567.json
+++ b/integration-tests/mocks/slack-api/data/conversations_history_C01234567.json
@@ -1,0 +1,24 @@
+{
+  "ok": true,
+  "messages": [
+    {
+      "type": "message",
+      "user": "U01234567",
+      "text": "Hello everyone!",
+      "ts": "1614267200.000100"
+    },
+    {
+      "type": "message",
+      "user": "U01234568",
+      "text": "Hi there!",
+      "ts": "1614267300.000200"
+    },
+    {
+      "type": "message",
+      "user": "U01234569",
+      "text": "Good morning!",
+      "ts": "1614267400.000300"
+    }
+  ],
+  "has_more": false
+}

--- a/integration-tests/mocks/slack-api/data/oauth.json
+++ b/integration-tests/mocks/slack-api/data/oauth.json
@@ -1,0 +1,21 @@
+{
+  "ok": true,
+  "access_token": "xoxb-test-token",
+  "token_type": "bot",
+  "scope": "channels:history,channels:read,users:read",
+  "bot_user_id": "B12345",
+  "app_id": "A12345",
+  "team": {
+    "id": "T12345",
+    "name": "Test Team",
+    "domain": "testteam"
+  },
+  "enterprise": null,
+  "authed_user": {
+    "id": "U12345",
+    "scope": "chat:write",
+    "access_token": "xoxp-test-token",
+    "token_type": "user"
+  },
+  "is_enterprise_install": false
+}

--- a/integration-tests/mocks/slack-api/data/users.json
+++ b/integration-tests/mocks/slack-api/data/users.json
@@ -3,30 +3,115 @@
   "members": [
     {
       "id": "U01234567",
+      "team_id": "T12345",
       "name": "user1",
+      "deleted": false,
+      "color": "9f69e7",
       "real_name": "User One",
+      "tz": "Asia/Tokyo",
+      "tz_label": "Japan Standard Time",
+      "tz_offset": 32400,
       "profile": {
+        "title": "",
+        "phone": "",
+        "skype": "",
+        "real_name": "User One",
+        "real_name_normalized": "User One",
         "display_name": "User 1",
-        "email": "user1@example.com"
-      }
+        "display_name_normalized": "User 1",
+        "email": "user1@example.com",
+        "status_text": "",
+        "status_emoji": "",
+        "status_expiration": 0,
+        "avatar_hash": "g12345",
+        "image_24": "https://secure.gravatar.com/avatar/user1.jpg?s=24",
+        "image_32": "https://secure.gravatar.com/avatar/user1.jpg?s=32",
+        "image_48": "https://secure.gravatar.com/avatar/user1.jpg?s=48"
+      },
+      "is_admin": false,
+      "is_owner": false,
+      "is_primary_owner": false,
+      "is_restricted": false,
+      "is_ultra_restricted": false,
+      "is_bot": false,
+      "is_app_user": false,
+      "updated": 1614267200
     },
     {
       "id": "U01234568",
+      "team_id": "T12345",
       "name": "user2",
+      "deleted": false,
+      "color": "4bbe2e",
       "real_name": "User Two",
+      "tz": "Asia/Tokyo",
+      "tz_label": "Japan Standard Time",
+      "tz_offset": 32400,
       "profile": {
+        "title": "",
+        "phone": "",
+        "skype": "",
+        "real_name": "User Two",
+        "real_name_normalized": "User Two",
         "display_name": "User 2",
-        "email": "user2@example.com"
-      }
+        "display_name_normalized": "User 2",
+        "email": "user2@example.com",
+        "status_text": "",
+        "status_emoji": "",
+        "status_expiration": 0,
+        "avatar_hash": "g23456",
+        "image_24": "https://secure.gravatar.com/avatar/user2.jpg?s=24",
+        "image_32": "https://secure.gravatar.com/avatar/user2.jpg?s=32",
+        "image_48": "https://secure.gravatar.com/avatar/user2.jpg?s=48"
+      },
+      "is_admin": false,
+      "is_owner": false,
+      "is_primary_owner": false,
+      "is_restricted": false,
+      "is_ultra_restricted": false,
+      "is_bot": false,
+      "is_app_user": false,
+      "updated": 1614267300
     },
     {
       "id": "U01234569",
+      "team_id": "T12345",
       "name": "user3",
+      "deleted": false,
+      "color": "e7392d",
       "real_name": "User Three",
+      "tz": "Asia/Tokyo",
+      "tz_label": "Japan Standard Time",
+      "tz_offset": 32400,
       "profile": {
+        "title": "",
+        "phone": "",
+        "skype": "",
+        "real_name": "User Three",
+        "real_name_normalized": "User Three",
         "display_name": "User 3",
-        "email": "user3@example.com"
-      }
+        "display_name_normalized": "User 3",
+        "email": "user3@example.com",
+        "status_text": "",
+        "status_emoji": "",
+        "status_expiration": 0,
+        "avatar_hash": "g34567",
+        "image_24": "https://secure.gravatar.com/avatar/user3.jpg?s=24",
+        "image_32": "https://secure.gravatar.com/avatar/user3.jpg?s=32",
+        "image_48": "https://secure.gravatar.com/avatar/user3.jpg?s=48"
+      },
+      "is_admin": false,
+      "is_owner": false,
+      "is_primary_owner": false,
+      "is_restricted": false,
+      "is_ultra_restricted": false,
+      "is_bot": false,
+      "is_app_user": false,
+      "updated": 1614267400
     }
-  ]
+  ],
+  "cache_ts": 1614267500,
+  "response_metadata": {
+    "next_cursor": ""
+  }
 }

--- a/integration-tests/mocks/slack-api/data/users.json
+++ b/integration-tests/mocks/slack-api/data/users.json
@@ -1,0 +1,32 @@
+{
+  "ok": true,
+  "members": [
+    {
+      "id": "U01234567",
+      "name": "user1",
+      "real_name": "User One",
+      "profile": {
+        "display_name": "User 1",
+        "email": "user1@example.com"
+      }
+    },
+    {
+      "id": "U01234568",
+      "name": "user2",
+      "real_name": "User Two",
+      "profile": {
+        "display_name": "User 2",
+        "email": "user2@example.com"
+      }
+    },
+    {
+      "id": "U01234569",
+      "name": "user3",
+      "real_name": "User Three",
+      "profile": {
+        "display_name": "User 3",
+        "email": "user3@example.com"
+      }
+    }
+  ]
+}

--- a/integration-tests/mocks/slack-api/server.js
+++ b/integration-tests/mocks/slack-api/server.js
@@ -1,18 +1,36 @@
 const express = require('express');
 const bodyParser = require('body-parser');
+const fs = require('fs');
+const path = require('path');
 
 const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(bodyParser.json());
 
+const loadDataFromFile = (filename, defaultData) => {
+  try {
+    const dataPath = path.join(__dirname, 'data', filename);
+    if (fs.existsSync(dataPath)) {
+      const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+      console.log(`Loaded data from ${dataPath}`);
+      return data;
+    } else {
+      console.log(`File ${dataPath} not found, using default data`);
+      return defaultData;
+    }
+  } catch (error) {
+    console.error(`Error loading data from ${filename}:`, error);
+    return defaultData;
+  }
+};
+
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok' });
 });
 
-
 app.get('/api/conversations.list', (req, res) => {
-  res.json({
+  const data = loadDataFromFile('conversations.json', {
     ok: true,
     channels: [
       {
@@ -31,10 +49,11 @@ app.get('/api/conversations.list', (req, res) => {
       }
     ]
   });
+  res.json(data);
 });
 
 app.get('/api/users.list', (req, res) => {
-  res.json({
+  const data = loadDataFromFile('users.json', {
     ok: true,
     members: [
       {
@@ -57,10 +76,12 @@ app.get('/api/users.list', (req, res) => {
       }
     ]
   });
+  res.json(data);
 });
 
 app.get('/api/conversations.history', (req, res) => {
-  res.json({
+  const channelId = req.query.channel || 'C01234567';
+  const data = loadDataFromFile(`conversations_history_${channelId}.json`, {
     ok: true,
     messages: [
       {
@@ -78,6 +99,59 @@ app.get('/api/conversations.history', (req, res) => {
     ],
     has_more: false
   });
+  res.json(data);
+});
+
+app.get('/api/users.info', (req, res) => {
+  const userId = req.query.user;
+  if (!userId) {
+    return res.json({ ok: false, error: 'user_not_found' });
+  }
+
+  const usersData = loadDataFromFile('users.json', {
+    members: [
+      { id: 'U01234567', name: 'user1', real_name: 'User One' },
+      { id: 'U01234568', name: 'user2', real_name: 'User Two' }
+    ]
+  });
+
+  const user = usersData.members.find(u => u.id === userId);
+  if (!user) {
+    return res.json({ ok: false, error: 'user_not_found' });
+  }
+
+  res.json({ ok: true, user });
+});
+
+app.post('/api/oauth.v2.access', (req, res) => {
+  const data = loadDataFromFile('oauth.json', {
+    ok: true,
+    access_token: 'xoxb-test-token',
+    token_type: 'bot',
+    scope: 'channels:history,channels:read,users:read',
+    bot_user_id: 'B12345',
+    app_id: 'A12345',
+    team: {
+      id: 'T12345',
+      name: 'Test Team',
+      domain: 'testteam'
+    },
+    enterprise: null,
+    authed_user: {
+      id: 'U12345',
+      scope: 'chat:write',
+      access_token: 'xoxp-test-token',
+      token_type: 'user'
+    },
+    is_enterprise_install: false
+  });
+  
+  const { client_id, client_secret, code } = req.body;
+  if (!client_id || !client_secret || !code) {
+    return res.json({ ok: false, error: 'invalid_request' });
+  }
+  
+  res.json(data);
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
# Implement Slack API Mock Service

This PR implements a Slack API Mock Service for integration testing as described in issue #261.

## Changes
- Enhanced the existing server.js to implement all required Slack API endpoints
- Added a data loading mechanism from JSON files
- Created a data directory structure for test data
- Implemented the missing `/api/users.info` endpoint
- Implemented the missing `/api/oauth.v2.access` endpoint
- Created sample JSON files for test data

## Related Issues
- Fixes #261

## Testing
- Verified the server.js file syntax
- Created sample JSON files that follow the Slack API response format

Link to Devin run: https://app.devin.ai/sessions/fa81f7329b774be7909e507f970ac446
Requested by: Hal Seki ([hal@code4japan.org](mailto:hal@code4japan.org))