### PR TITLE
Fix migration revision ID mismatch for remove_workspace_analysis_tables

### DIFF
--- a/backend/alembic/versions/remove_workspace_analysis_tables.py
+++ b/backend/alembic/versions/remove_workspace_analysis_tables.py
@@ -1,6 +1,6 @@
 """remove_workspace_analysis_tables
 
-Revision ID: remove_workspace_analysis
+Revision ID: remove_workspace_analysis_tables
 Revises: ea5ebf7c670a
 Create Date: 2025-04-24 12:00:00.000000
 
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "remove_workspace_analysis"
+revision = "remove_workspace_analysis_tables"
 down_revision = "ea5ebf7c670a"  # Make sure this matches your latest migration
 branch_labels = None
 depends_on = None

--- a/backend/scripts/run_analysis.py
+++ b/backend/scripts/run_analysis.py
@@ -32,8 +32,8 @@ os.environ["OPENAI_API_KEY"] = "debug_openai_key"
 os.environ["OPENROUTER_API_KEY"] = "debug_openrouter_key"
 
 from app.models.integration import Integration
-from app.models.reports.cross_resource_report import CrossResourceReport, ResourceAnalysis
 from app.models.reports import AnalysisType
+from app.models.reports.cross_resource_report import CrossResourceReport, ResourceAnalysis
 from app.models.slack import SlackChannel, SlackMessage, SlackUser, SlackWorkspace
 from app.services.analysis.slack_channel import SlackChannelAnalysisService
 from app.services.llm.openrouter import OpenRouterService


### PR DESCRIPTION
# Fix Backend Migration Error in Integration Testing Environment

## Issue
Fixes #284

The backend container was failing to start in the integration testing environment due to a KeyError related to the "remove_workspace_analysis_tables" migration. 

## Root Cause
There was a mismatch between the revision ID in the migration file and how it's referenced in other migration files:
- In "remove_workspace_analysis_tables.py", the revision ID was set to "remove_workspace_analysis"
- But in "add_count_fields.py", it was referenced as "remove_workspace_analysis_tables"

## Fix
Updated the revision ID in "remove_workspace_analysis_tables.py" to match its filename and how it's referenced in other migration files.

## Testing
- Verified that the backend container starts successfully in the integration test environment
- Confirmed that database migrations run without errors
- Ran the integration tests to ensure they can execute against the backend

## Link to Devin run
https://app.devin.ai/sessions/ae11a4d554aa461e8f176370c66aacc0

Requested by: Hal Seki ([hal@code4japan.org](mailto:hal@code4japan.org))