### PR TITLE
Devin/1746532369 fix migration revision

### DIFF
--- a/backend/alembic/versions/remove_workspace_analysis_tables.py
+++ b/backend/alembic/versions/remove_workspace_analysis_tables.py
@@ -1,6 +1,6 @@
 """remove_workspace_analysis_tables
 
-Revision ID: remove_workspace_analysis
+Revision ID: remove_workspace_analysis_tables
 Revises: ea5ebf7c670a
 Create Date: 2025-04-24 12:00:00.000000
 
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "remove_workspace_analysis"
+revision = "remove_workspace_analysis_tables"
 down_revision = "ea5ebf7c670a"  # Make sure this matches your latest migration
 branch_labels = None
 depends_on = None

--- a/backend/scripts/run_analysis.py
+++ b/backend/scripts/run_analysis.py
@@ -32,8 +32,8 @@ os.environ["OPENAI_API_KEY"] = "debug_openai_key"
 os.environ["OPENROUTER_API_KEY"] = "debug_openrouter_key"
 
 from app.models.integration import Integration
-from app.models.reports.cross_resource_report import CrossResourceReport, ResourceAnalysis
 from app.models.reports import AnalysisType
+from app.models.reports.cross_resource_report import CrossResourceReport, ResourceAnalysis
 from app.models.slack import SlackChannel, SlackMessage, SlackUser, SlackWorkspace
 from app.services.analysis.slack_channel import SlackChannelAnalysisService
 from app.services.llm.openrouter import OpenRouterService

--- a/integration-tests/docker-compose.test.yml
+++ b/integration-tests/docker-compose.test.yml
@@ -44,7 +44,7 @@ services:
         uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
       "
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
markdown
# Fix Backend Migration Error and Integration Test Issues

## Issues Fixed
Fixes #284

1. Fixed migration revision ID mismatch in remove_workspace_analysis_tables.py
2. Fixed isort issues in backend/scripts/run_analysis.py
3. Fixed health check endpoint path in docker-compose.test.yml

## Root Cause
1. In "remove_workspace_analysis_tables.py", the revision ID was set to "remove_workspace_analysis" but was referenced as "remove_workspace_analysis_tables" in other files
2. Import order in run_analysis.py did not comply with isort standards
3. Health check in docker-compose.test.yml was pointing to "/api/v1/health" but the actual endpoint is "/health"

## Testing
- Verified that the backend container starts successfully in the integration test environment
- Confirmed that database migrations run without errors
- Verified that the health check endpoint works correctly
- Confirmed that isort checks pass

## Link to Devin run
https://app.devin.ai/sessions/ae11a4d554aa461e8f176370c66aacc0

Requested by: Hal Seki ([hal@code4japan.org](mailto:hal@code4japan.org))